### PR TITLE
fix/#60/sub goal update

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/GoalConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/GoalConverter.java
@@ -1,134 +1,101 @@
 package com.hotpack.krocs.domain.goals.converter;
 
-import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.global.common.entity.Priority;
-
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import java.time.LocalDate;
 
 @Component
 @RequiredArgsConstructor
 public class GoalConverter {
 
-    public Goal toEntity(GoalCreateRequestDTO requestDTO) {
-        return Goal.builder()
-                .title(requestDTO.getTitle())
-                .priority(requestDTO.getPriority() != null ? requestDTO.getPriority() : Priority.MEDIUM)
-                .startDate(requestDTO.getStartDate())
-                .endDate(requestDTO.getEndDate())
-                .duration(requestDTO.getDuration())
-                .isCompleted(false)
-                .build();
+  public Goal toEntity(GoalCreateRequestDTO requestDTO) {
+    return Goal.builder()
+        .title(requestDTO.getTitle())
+        .priority(requestDTO.getPriority() != null ? requestDTO.getPriority() : Priority.MEDIUM)
+        .startDate(requestDTO.getStartDate())
+        .endDate(requestDTO.getEndDate())
+        .duration(requestDTO.getDuration())
+        .isCompleted(false)
+        .build();
+  }
+
+  public GoalCreateResponseDTO toCreateResponseDTO(Goal goal) {
+    List<SubGoalResponseDTO> subGoalResponseDTOs = goal.getSubGoals() != null ?
+        goal.getSubGoals().stream()
+            .map(this::toSubGoalResponseDTO)
+            .collect(Collectors.toList()) :
+        List.of();
+
+    return GoalCreateResponseDTO.builder()
+        .goalId(goal.getGoalId())
+        .title(goal.getTitle())
+        .priority(goal.getPriority())
+        .startDate(goal.getStartDate())
+        .endDate(goal.getEndDate())
+        .duration(goal.getDuration())
+        .completed(goal.getIsCompleted())
+        .subGoals(subGoalResponseDTOs)
+        .createdAt(goal.getCreatedAt())
+        .updatedAt(goal.getUpdatedAt())
+        .build();
+  }
+
+  private SubGoalResponseDTO toSubGoalResponseDTO(
+      com.hotpack.krocs.domain.goals.domain.SubGoal subGoal) {
+    return SubGoalResponseDTO.builder()
+        .subGoalId(subGoal.getSubGoalId())
+        .title(subGoal.getTitle())
+        .completed(subGoal.getIsCompleted())
+        .completionPercentage(subGoal.getIsCompleted() ? 100 : 0)
+        .build();
+  }
+
+  public List<GoalResponseDTO> toGoalResponseDTO(List<Goal> goals) {
+    return goals.stream()
+        .map(this::toGoalResponseDTO)
+        .collect(Collectors.toList());
+  }
+
+  public GoalResponseDTO toGoalResponseDTO(Goal goal) {
+    List<SubGoalResponseDTO> subGoalResponseDTOs = goal.getSubGoals() != null ?
+        goal.getSubGoals().stream()
+            .map(this::toSubGoalResponseDTO)
+            .collect(Collectors.toList()) :
+        List.of();
+
+    int completionPercentage = calculateCompletionPercentage(goal);
+
+    return GoalResponseDTO.builder()
+        .goalId(goal.getGoalId())
+        .title(goal.getTitle())
+        .priority(goal.getPriority())
+        .startDate(goal.getStartDate())
+        .endDate(goal.getEndDate())
+        .duration(goal.getDuration())
+        .isCompleted(goal.getIsCompleted())
+        .subGoals(subGoalResponseDTOs)
+        .completionPercentage(completionPercentage)
+        .createdAt(goal.getCreatedAt())
+        .updatedAt(goal.getUpdatedAt())
+        .build();
+  }
+
+  private int calculateCompletionPercentage(Goal goal) {
+    if (goal.getSubGoals() == null || goal.getSubGoals().isEmpty()) {
+      return goal.getIsCompleted() ? 100 : 0;
     }
 
-    public Goal toEntity(Goal existingGoal, GoalUpdateRequestDTO requestDTO) {
-        String title = existingGoal.getTitle();
-        if (requestDTO.getTitle() != null) title = requestDTO.getTitle();
+    long completedCount = goal.getSubGoals().stream()
+        .filter(com.hotpack.krocs.domain.goals.domain.SubGoal::getIsCompleted)
+        .count();
 
-        Priority priority = existingGoal.getPriority();
-        if (requestDTO.getPriority() != null) priority = requestDTO.getPriority();
-
-        LocalDate startDate = existingGoal.getStartDate();
-        if (requestDTO.getStartDate() != null) startDate = requestDTO.getStartDate();
-
-        LocalDate endDate = existingGoal.getEndDate();
-        if (requestDTO.getEndDate() != null) endDate = requestDTO.getEndDate();
-
-        Integer duration = existingGoal.getDuration();
-        if (requestDTO.getDuration() != null) duration = requestDTO.getDuration();
-
-        Boolean isCompleted = existingGoal.getIsCompleted();
-        if (requestDTO.getIsCompleted() != null) isCompleted = requestDTO.getIsCompleted();
-
-        return Goal.builder()
-                .goalId(existingGoal.getGoalId())
-                .title(title)
-                .priority(priority)
-                .startDate(startDate)
-                .endDate(endDate)
-                .duration(duration)
-                .isCompleted(isCompleted)
-                .subGoals(existingGoal.getSubGoals())
-                .build();
-    }
-
-    public GoalCreateResponseDTO toCreateResponseDTO(Goal goal) {
-        List<SubGoalResponseDTO> subGoalResponseDTOs = goal.getSubGoals() != null ?
-                goal.getSubGoals().stream()
-                        .map(this::toSubGoalResponseDTO)
-                        .collect(Collectors.toList()) :
-                List.of();
-
-        return GoalCreateResponseDTO.builder()
-                .goalId(goal.getGoalId())
-                .title(goal.getTitle())
-                .priority(goal.getPriority())
-                .startDate(goal.getStartDate())
-                .endDate(goal.getEndDate())
-                .duration(goal.getDuration())
-                .completed(goal.getIsCompleted())
-                .subGoals(subGoalResponseDTOs)
-                .createdAt(goal.getCreatedAt())
-                .updatedAt(goal.getUpdatedAt())
-                .build();
-    }
-
-    private SubGoalResponseDTO toSubGoalResponseDTO(com.hotpack.krocs.domain.goals.domain.SubGoal subGoal) {
-        return SubGoalResponseDTO.builder()
-                .subGoalId(subGoal.getSubGoalId())
-                .title(subGoal.getTitle())
-                .completed(subGoal.getIsCompleted())
-                .completionPercentage(subGoal.getIsCompleted() ? 100 : 0)
-                .build();
-    }
-
-    public List<GoalResponseDTO> toGoalResponseDTO(List<Goal> goals) {
-        return goals.stream()
-                .map(this::toGoalResponseDTO)
-                .collect(Collectors.toList());
-    }
-
-    public GoalResponseDTO toGoalResponseDTO(Goal goal) {
-        List<SubGoalResponseDTO> subGoalResponseDTOs = goal.getSubGoals() != null ?
-                goal.getSubGoals().stream()
-                        .map(this::toSubGoalResponseDTO)
-                        .collect(Collectors.toList()) :
-                List.of();
-
-        int completionPercentage = calculateCompletionPercentage(goal);
-
-        return GoalResponseDTO.builder()
-                .goalId(goal.getGoalId())
-                .title(goal.getTitle())
-                .priority(goal.getPriority())
-                .startDate(goal.getStartDate())
-                .endDate(goal.getEndDate())
-                .duration(goal.getDuration())
-                .isCompleted(goal.getIsCompleted())
-                .subGoals(subGoalResponseDTOs)
-                .completionPercentage(completionPercentage)
-                .createdAt(goal.getCreatedAt())
-                .updatedAt(goal.getUpdatedAt())
-                .build();
-    }
-
-    private int calculateCompletionPercentage(Goal goal) {
-        if (goal.getSubGoals() == null || goal.getSubGoals().isEmpty()) {
-            return goal.getIsCompleted() ? 100 : 0;
-        }
-
-        long completedCount = goal.getSubGoals().stream()
-                .filter(com.hotpack.krocs.domain.goals.domain.SubGoal::getIsCompleted)
-                .count();
-
-        return (int) ((completedCount * 100) / goal.getSubGoals().size());
-    }
+    return (int) ((completedCount * 100) / goal.getSubGoals().size());
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/GoalConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/GoalConverter.java
@@ -1,6 +1,7 @@
 package com.hotpack.krocs.domain.goals.converter;
 
 import com.hotpack.krocs.domain.goals.domain.Goal;
+import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
@@ -48,12 +49,11 @@ public class GoalConverter {
   }
 
   private SubGoalResponseDTO toSubGoalResponseDTO(
-      com.hotpack.krocs.domain.goals.domain.SubGoal subGoal) {
+      SubGoal subGoal) {
     return SubGoalResponseDTO.builder()
         .subGoalId(subGoal.getSubGoalId())
         .title(subGoal.getTitle())
         .completed(subGoal.getIsCompleted())
-        .completionPercentage(subGoal.getIsCompleted() ? 100 : 0)
         .build();
   }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/SubGoalConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/SubGoalConverter.java
@@ -36,7 +36,6 @@ public class SubGoalConverter {
         .subGoalId(subGoal.getSubGoalId())
         .title(subGoal.getTitle())
         .completed(subGoal.getIsCompleted())
-        .completionPercentage(subGoal.getIsCompleted() ? 100 : 0)
         .build();
   }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/SubGoalConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/converter/SubGoalConverter.java
@@ -4,7 +4,6 @@ import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.SubGoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalUpdateResponseDTO;
 import java.util.ArrayList;
@@ -20,25 +19,6 @@ public class SubGoalConverter {
     return SubGoal.builder()
         .goal(goal)
         .title(requestDTO.getTitle())
-        .build();
-  }
-  
-  public SubGoal toSubGoalEntity(SubGoal subGoal, SubGoalUpdateRequestDTO requestDTO) {
-    String title = subGoal.getTitle();
-    if (requestDTO.getTitle() != null) {
-      title = requestDTO.getTitle();
-    }
-
-    boolean isCompleted = subGoal.getIsCompleted();
-    if (requestDTO.getIsCompleted() != null) {
-      isCompleted = requestDTO.getIsCompleted();
-    }
-
-    return SubGoal.builder()
-        .subGoalId(subGoal.getSubGoalId())
-        .goal(subGoal.getGoal())
-        .title(title)
-        .isCompleted(isCompleted)
         .build();
   }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/domain/Goal.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/domain/Goal.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.domain.goals.domain;
 
+import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.global.common.entity.BaseTimeEntity;
 import com.hotpack.krocs.global.common.entity.Priority;
 import jakarta.persistence.CascadeType;
@@ -60,4 +61,22 @@ public class Goal extends BaseTimeEntity {
 
   @OneToMany(mappedBy = "goal", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private List<SubGoal> subGoals;
+
+  public void updateFrom(GoalUpdateRequestDTO requestDTO) {
+    if (requestDTO.getTitle() != null) {
+      this.title = requestDTO.getTitle();
+    }
+
+    if (requestDTO.getStartDate() != null) {
+      this.startDate = requestDTO.getStartDate();
+    }
+
+    if (requestDTO.getEndDate() != null) {
+      this.endDate = requestDTO.getEndDate();
+    }
+
+    if (requestDTO.getDuration() != null) {
+      this.duration = requestDTO.getDuration();
+    }
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/domain/Goal.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/domain/Goal.java
@@ -67,6 +67,10 @@ public class Goal extends BaseTimeEntity {
       this.title = requestDTO.getTitle();
     }
 
+    if (requestDTO.getPriority() != null) {
+      this.priority = requestDTO.getPriority();
+    }
+
     if (requestDTO.getStartDate() != null) {
       this.startDate = requestDTO.getStartDate();
     }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/domain/SubGoal.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/domain/SubGoal.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.domain.goals.domain;
 
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalUpdateRequestDTO;
 import com.hotpack.krocs.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class SubGoal extends BaseTimeEntity {
-
+  
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "sub_goal_id")
@@ -38,4 +39,14 @@ public class SubGoal extends BaseTimeEntity {
   @Column(name = "is_completed", nullable = false)
   @Builder.Default
   private Boolean isCompleted = false;
+
+  public void updateFrom(SubGoalUpdateRequestDTO requestDTO) {
+    if (requestDTO.getTitle() != null) {
+      this.title = requestDTO.getTitle();
+    }
+
+    if (requestDTO.getIsCompleted() != null) {
+      this.isCompleted = requestDTO.getIsCompleted();
+    }
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/SubGoalResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/SubGoalResponseDTO.java
@@ -14,6 +14,4 @@ public class SubGoalResponseDTO {
   private final String title;
 
   private final Boolean completed;
-
-  private final Integer completionPercentage;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
@@ -4,66 +4,61 @@ import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.repository.GoalRepository;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GoalRepositoryFacade {
-    private final GoalRepository goalRepository;
 
-    @Transactional
-    public Goal saveGoal(Goal goal) {
-        return goalRepository.save(goal);
-    }
+  private final GoalRepository goalRepository;
 
-    public Goal findGoalById(Long id) {
-        return goalRepository.findById(id)
-            .orElseThrow(() -> new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND));
-    }
+  @Transactional
+  public Goal saveGoal(Goal goal) {
+    return goalRepository.save(goal);
+  }
 
-    public List<Goal> findGoalByDate(LocalDate date) {
-        return goalRepository.findByDate(date);
-    }
+  public Goal findGoalById(Long id) {
+    return goalRepository.findById(id)
+        .orElseThrow(() -> new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND));
+  }
 
-    public List<Goal> findAllGoals() {
-        return goalRepository.findAll();
-    }
+  public List<Goal> findGoalByDate(LocalDate date) {
+    return goalRepository.findByDate(date);
+  }
 
-    public Goal findGoalByGoalId(Long goalId) {
-        return goalRepository.findGoalByGoalId(goalId);
-    }
+  public List<Goal> findAllGoals() {
+    return goalRepository.findAll();
+  }
 
-    @Transactional
-    public Goal updateGoal(Goal goal) {
-        return goalRepository.save(goal);
-    }
+  public Goal findGoalByGoalId(Long goalId) {
+    return goalRepository.findGoalByGoalId(goalId);
+  }
 
-    public Goal findById(Long goalId) {
-        return goalRepository.findGoalByGoalId(goalId);
-    }
+  public Goal findById(Long goalId) {
+    return goalRepository.findGoalByGoalId(goalId);
+  }
 
-    @Transactional
-    public void deleteGoal(Long goalId) {
-        goalRepository.deleteById(goalId);
-    }
+  @Transactional
+  public void deleteGoal(Long goalId) {
+    goalRepository.deleteById(goalId);
+  }
 
-    public boolean existsById(Long goalId) {
-        return goalRepository.existsById(goalId);
-    }
+  public boolean existsById(Long goalId) {
+    return goalRepository.existsById(goalId);
+  }
 
-    public boolean existsByTitle(String title) {
-        return goalRepository.existsByTitle(title);
-    }
+  public boolean existsByTitle(String title) {
+    return goalRepository.existsByTitle(title);
+  }
 
-    public boolean existsByTitleAndGoalIdNot(String title, Long goalId) {
-        return goalRepository.existsByTitleAndGoalIdNot(title, goalId);
-    }
+  public boolean existsByTitleAndGoalIdNot(String title, Long goalId) {
+    return goalRepository.existsByTitleAndGoalIdNot(title, goalId);
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/SubGoalRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/SubGoalRepositoryFacade.java
@@ -11,9 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * SubGoal Repository Facade 데이터 접근 계층을 추상화합니다.
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -22,26 +19,16 @@ public class SubGoalRepositoryFacade {
 
   private final SubGoalRepository subGoalRepository;
 
-  /**
-   * 소목표(SubGoal)를 리스트로 입력 받아 모두 DB에 저장합니다.
-   *
-   * @param subGoals
-   * @return
-   */
   @Transactional
   public List<SubGoal> saveSubGoals(List<SubGoal> subGoals) {
     return subGoalRepository.saveAll(subGoals);
   }
 
-  /**
-   * 주어진 Goal에 속한 모든 소목표를 조회합니다.
-   *
-   * <p>소목표가 하나도 없을 경우 SUB_GOAL_NOT_FOUND 예외를 던집니다.
-   *
-   * @param goal 소속된 Goal
-   * @return 해당 Goal에 연결된 소목표 리스트
-   * @throws SubGoalException SUB_GOAL_NOT_FOUND (소목표가 없는 경우)
-   */
+  @Transactional
+  public SubGoal saveSubGoal(SubGoal subGoal) {
+    return subGoalRepository.save(subGoal);
+  }
+
   public List<SubGoal> findSubGoalsByGoal(Goal goal) {
     List<SubGoal> subGoals = subGoalRepository.findSubGoalsByGoal(goal);
     if (subGoals.isEmpty()) {
@@ -51,16 +38,6 @@ public class SubGoalRepositoryFacade {
     return subGoals;
   }
 
-
-  /**
-   * 주어진 ID에 해당하는 소목표를 조회합니다.
-   *
-   * <p>null인 경우 예외를 던집니다.
-   *
-   * @param subGoalId 조회할 소목표의 ID
-   * @return 해당 ID에 해당하는 SubGoal
-   * @throws SubGoalException SUB_GOAL_NOT_FOUND (해당 ID가 존재하지 않는 경우)
-   */
   public SubGoal findSubGoalBySubGoalId(Long subGoalId) {
     SubGoal subGoal = subGoalRepository.findSubGoalsBySubGoalId(subGoalId);
     if (subGoal == null) {
@@ -70,14 +47,6 @@ public class SubGoalRepositoryFacade {
     return subGoal;
   }
 
-  /**
-   * 주어진 ID에 해당하는 소목표를 삭제합니다.
-   *
-   * <p>삭제 전 해당 소목표 존재 여부를 먼저 검증합니다.
-   *
-   * @param subGoalId 삭제할 소목표의 ID
-   * @throws SubGoalException SUB_GOAL_NOT_FOUND (삭제 대상이 존재하지 않는 경우)
-   */
   @Transactional
   public void deleteSubGoalBySubGoalId(Long subGoalId) {
     findSubGoalBySubGoalId(subGoalId);

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
@@ -5,27 +5,26 @@ import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
-
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.time.LocalDate;
 
 
 @Slf4j
@@ -33,223 +32,227 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GoalServiceImpl implements GoalService {
-    private final SubGoalRepositoryFacade subGoalRepositoryFacade;
-    private final SubGoalConverter subGoalConverter;
-    private final GoalRepositoryFacade goalRepositoryFacade;
-    private final GoalConverter goalConverter;
-    private final GoalValidator goalValidator;
 
-    @Override
-    @Transactional
-    public GoalCreateResponseDTO createGoal(GoalCreateRequestDTO requestDTO, Long userId) {
-        try {
-            goalValidator.validateGoalCreation(requestDTO);
+  private final SubGoalRepositoryFacade subGoalRepositoryFacade;
+  private final SubGoalConverter subGoalConverter;
+  private final GoalRepositoryFacade goalRepositoryFacade;
+  private final GoalConverter goalConverter;
+  private final GoalValidator goalValidator;
 
-            if (goalRepositoryFacade.existsByTitle(requestDTO.getTitle())) {
-                throw new GoalException(GoalExceptionType.GOAL_DUPLICATE_TITLE);
-            }
-            Goal goal = goalConverter.toEntity(requestDTO);
-            Goal savedGoal = goalRepositoryFacade.saveGoal(goal);
+  @Override
+  @Transactional
+  public GoalCreateResponseDTO createGoal(GoalCreateRequestDTO requestDTO, Long userId) {
+    try {
+      goalValidator.validateGoalCreation(requestDTO);
 
-            return goalConverter.toCreateResponseDTO(savedGoal);
-        } catch (GoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("대목표 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new GoalException(GoalExceptionType.GOAL_CREATION_FAILED);
-        }
+      if (goalRepositoryFacade.existsByTitle(requestDTO.getTitle())) {
+        throw new GoalException(GoalExceptionType.GOAL_DUPLICATE_TITLE);
+      }
+      Goal goal = goalConverter.toEntity(requestDTO);
+      Goal savedGoal = goalRepositoryFacade.saveGoal(goal);
+
+      return goalConverter.toCreateResponseDTO(savedGoal);
+    } catch (GoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("대목표 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new GoalException(GoalExceptionType.GOAL_CREATION_FAILED);
+    }
+  }
+
+  @Override
+  public List<GoalResponseDTO> getGoalByUser(Long userId, LocalDate date) {
+    try {
+      List<Goal> goals;
+      if (date != null) {
+        goals = goalRepositoryFacade.findGoalByDate(date);
+      } else {
+        goals = goalRepositoryFacade.findAllGoals();
+      }
+      return goalConverter.toGoalResponseDTO(goals);
+    } catch (GoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("대목표 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
+    }
+  }
+
+  @Override
+  public GoalResponseDTO getGoalByGoalId(Long userId, Long goalId) {
+    try {
+      goalValidator.validateGoalIdParameter(goalId);
+
+      Goal existingGoal = goalRepositoryFacade.findById(goalId);
+      if (existingGoal == null) {
+        throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
+      }
+
+      return goalConverter.toGoalResponseDTO(existingGoal);
+    } catch (GoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("대목표 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
+    }
+  }
+
+  @Override
+  @Transactional
+  public GoalResponseDTO updateGoalById(Long goalId, GoalUpdateRequestDTO requestDTO, Long userId) {
+    try {
+      goalValidator.validateGoalIdParameter(goalId);
+
+      Goal existingGoal = goalRepositoryFacade.findById(goalId);
+      if (existingGoal == null) {
+        throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
+      }
+
+      if (requestDTO.getTitle() != null) {
+        goalValidator.validateTitle(requestDTO.getTitle());
+      }
+      if (goalRepositoryFacade.existsByTitleAndGoalIdNot(requestDTO.getTitle(), goalId)) {
+        throw new GoalException(GoalExceptionType.GOAL_DUPLICATE_TITLE);
+      }
+      if (requestDTO.getStartDate() != null && requestDTO.getEndDate() != null) {
+        goalValidator.validateDateRange(requestDTO.getStartDate(), requestDTO.getEndDate());
+      } else if (requestDTO.getStartDate() != null) {
+        goalValidator.validateDateRange(requestDTO.getStartDate(), existingGoal.getEndDate());
+      } else if (requestDTO.getEndDate() != null) {
+        goalValidator.validateDateRange(existingGoal.getStartDate(), requestDTO.getEndDate());
+      }
+
+      if (requestDTO.getDuration() != null) {
+        goalValidator.validateDurationUpdate(requestDTO.getDuration());
+      }
+
+      existingGoal.updateFrom(requestDTO);
+      Goal updatedGoal = goalRepositoryFacade.findById(goalId);
+
+      return goalConverter.toGoalResponseDTO(updatedGoal);
+
+    } catch (GoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("대목표 수정 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new GoalException(GoalExceptionType.GOAL_UPDATE_FAILED);
+    }
+  }
+
+  @Override
+  @Transactional
+  public void deleteGoal(Long userId, Long goalId) {
+    try {
+      goalValidator.validateGoalIdParameter(goalId);
+      if (!goalRepositoryFacade.existsById(goalId)) {
+        throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
+      }
+
+      goalRepositoryFacade.deleteGoal(goalId);
+    } catch (GoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("대목표 삭제 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new GoalException(GoalExceptionType.GOAL_DELETE_FAILED);
+    }
+  }
+
+  @Override
+  @Transactional
+  public SubGoalCreateResponseDTO createSubGoals(Long goalId, SubGoalCreateRequestDTO requestDTO) {
+    try {
+      if (goalId == null) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
+      }
+      validateSubGoalCreation(requestDTO);
+
+      Goal goal = goalRepositoryFacade.findGoalById(goalId);
+
+      List<SubGoal> subGoals = subGoalConverter.toSubGoalEntityList(goal, requestDTO);
+      List<SubGoal> createdSubGoals = subGoalRepositoryFacade.saveSubGoals(subGoals);
+      List<SubGoalResponseDTO> subGoalResponseDTOs = subGoalConverter.toSubGoalResponseListDTO(
+          createdSubGoals);
+
+      return SubGoalCreateResponseDTO
+          .builder()
+          .goalId(goalId)
+          .createdSubGoals(subGoalResponseDTOs)
+          .build();
+
+    } catch (SubGoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("소목표 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
+    }
+  }
+
+  private void validateSubGoalCreation(SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
+    if (subGoalCreateRequestDTO.getSubGoals().isEmpty()) {
+      throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
     }
 
-    @Override
-    public List<GoalResponseDTO> getGoalByUser(Long userId, LocalDate date) {
-        try{
-            List<Goal> goals;
-            if (date != null) {
-                goals = goalRepositoryFacade.findGoalByDate(date);
-            } else {
-                goals = goalRepositoryFacade.findAllGoals();
-            }
-            return goalConverter.toGoalResponseDTO(goals);
-        }catch (GoalException e) {
-            throw e;
-        }catch (Exception e) {
-            log.error("대목표 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
-        }
+    for (SubGoalRequestDTO subGoalRequestDTO : subGoalCreateRequestDTO.getSubGoals()) {
+      if (subGoalRequestDTO.getTitle().isBlank()) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
+      }
+      if (subGoalRequestDTO.getTitle().length() > 200) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
+      }
     }
+  }
 
-    @Override
-    public GoalResponseDTO getGoalByGoalId(Long userId, Long goalId) {
-        try{
-            goalValidator.validateGoalIdParameter(goalId);
+  @Override
+  public SubGoalListResponseDTO getAllSubGoals(Long goalId) {
+    try {
+      if (goalId == null) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
+      }
 
-            Goal existingGoal = goalRepositoryFacade.findById(goalId);
-            if (existingGoal == null) {
-                throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
-            }
+      Goal goal = goalRepositoryFacade.findGoalById(goalId);
 
-            return goalConverter.toGoalResponseDTO(existingGoal);
-        }catch (GoalException e) {
-            throw e;
-        }catch (Exception e) {
-            log.error("대목표 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
-        }
+      List<SubGoal> subGoals = subGoalRepositoryFacade.findSubGoalsByGoal(goal);
+      if (subGoals.isEmpty()) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_FOUND);
+      }
+      List<SubGoalResponseDTO> subGoalResponseDTOS = subGoalConverter.toSubGoalResponseListDTO(
+          subGoals);
+
+      return SubGoalListResponseDTO
+          .builder()
+          .subGoals(subGoalResponseDTOS)
+          .build();
+    } catch (SubGoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("소목표 전체 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
     }
+  }
 
-    @Override
-    @Transactional
-    public GoalResponseDTO updateGoalById(Long goalId, GoalUpdateRequestDTO requestDTO, Long userId) {
-        try {
-            goalValidator.validateGoalIdParameter(goalId);
+  @Override
+  public SubGoalResponseDTO getSubGoal(Long goalId, Long subGoalId) {
+    try {
+      if (goalId == null) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
+      }
+      if (subGoalId == null) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
+      }
 
-            Goal existingGoal = goalRepositoryFacade.findById(goalId);
-            if (existingGoal == null) {
-                throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
-            }
+      Goal goal = goalRepositoryFacade.findGoalById(goalId);
+      List<SubGoal> subGoals = subGoalRepositoryFacade.findSubGoalsByGoal(goal);
+      SubGoal subGoal = subGoalRepositoryFacade.findSubGoalBySubGoalId(subGoalId);
+      if (!subGoals.contains(subGoal)) {
+        throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_BELONG_TO_GOAL);
+      }
+      return subGoalConverter.toSubGoalResponseDTO(subGoal);
 
-            if (requestDTO.getTitle() != null) {
-                goalValidator.validateTitle(requestDTO.getTitle());
-                if (goalRepositoryFacade.existsByTitleAndGoalIdNot(requestDTO.getTitle(), goalId)) {
-                    throw new GoalException(GoalExceptionType.GOAL_DUPLICATE_TITLE);
-                }
-            }
-
-            LocalDate startDate = existingGoal.getStartDate();
-            if (requestDTO.getStartDate() != null) startDate = requestDTO.getStartDate();
-
-            LocalDate endDate = existingGoal.getEndDate();
-            if (requestDTO.getEndDate() != null) endDate = requestDTO.getEndDate();
-
-            goalValidator.validateDateRange(startDate, endDate);
-
-            if (requestDTO.getDuration() != null) {
-                goalValidator.validateDurationUpdate(requestDTO.getDuration());
-            }
-
-            Goal goal = goalConverter.toEntity(existingGoal, requestDTO);
-            Goal savedGoal = goalRepositoryFacade.updateGoal(goal);
-            return goalConverter.toGoalResponseDTO(savedGoal);
-        } catch (GoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("대목표 수정 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new GoalException(GoalExceptionType.GOAL_UPDATE_FAILED);
-        }
+    } catch (SubGoalException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("소목표 단건 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
     }
-
-    @Override
-    @Transactional
-    public void deleteGoal(Long userId, Long goalId) {
-        try {
-            goalValidator.validateGoalIdParameter(goalId);
-            if (!goalRepositoryFacade.existsById(goalId)) {
-                throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
-            }
-
-            goalRepositoryFacade.deleteGoal(goalId);
-        } catch (GoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("대목표 삭제 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new GoalException(GoalExceptionType.GOAL_DELETE_FAILED);
-        }
-    }
-
-    @Override
-    @Transactional
-    public SubGoalCreateResponseDTO createSubGoals(Long goalId, SubGoalCreateRequestDTO requestDTO) {
-        try {
-            if (goalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-            }
-            validateSubGoalCreation(requestDTO);
-
-            Goal goal = goalRepositoryFacade.findGoalById(goalId);
-
-            List<SubGoal> subGoals = subGoalConverter.toSubGoalEntityList(goal, requestDTO);
-            List<SubGoal> createdSubGoals = subGoalRepositoryFacade.saveSubGoals(subGoals);
-            List<SubGoalResponseDTO> subGoalResponseDTOs = subGoalConverter.toSubGoalResponseListDTO(createdSubGoals);
-
-            return SubGoalCreateResponseDTO
-                  .builder()
-                  .goalId(goalId)
-                  .createdSubGoals(subGoalResponseDTOs)
-                  .build();
-
-        } catch (SubGoalException e) {
-          throw e;
-        } catch (Exception e) {
-          log.error("소목표 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-          throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
-        }
-    }
-
-    private void validateSubGoalCreation(SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
-        if (subGoalCreateRequestDTO.getSubGoals().isEmpty()) {
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
-        }
-
-        for (SubGoalRequestDTO subGoalRequestDTO : subGoalCreateRequestDTO.getSubGoals()) {
-            if (subGoalRequestDTO.getTitle().isBlank()) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
-            }
-            if (subGoalRequestDTO.getTitle().length() > 200) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
-            }
-        }
-    }
-
-    @Override
-    public SubGoalListResponseDTO getAllSubGoals(Long goalId) {
-        try {
-            if (goalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-            }
-
-            Goal goal = goalRepositoryFacade.findGoalById(goalId);
-
-            List<SubGoal> subGoals = subGoalRepositoryFacade.findSubGoalsByGoal(goal);
-            if (subGoals.isEmpty()) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_FOUND);
-            }
-            List<SubGoalResponseDTO> subGoalResponseDTOS = subGoalConverter.toSubGoalResponseListDTO(subGoals);
-
-        return SubGoalListResponseDTO
-                .builder()
-                .subGoals(subGoalResponseDTOS)
-                .build();
-        } catch (SubGoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("소목표 전체 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
-        }
-    }
-
-    @Override
-    public SubGoalResponseDTO getSubGoal(Long goalId, Long subGoalId) {
-        try {
-            if (goalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-            }
-            if (subGoalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
-            }
-
-            Goal goal = goalRepositoryFacade.findGoalById(goalId);
-            List<SubGoal> subGoals = subGoalRepositoryFacade.findSubGoalsByGoal(goal);
-            SubGoal subGoal = subGoalRepositoryFacade.findSubGoalBySubGoalId(subGoalId);
-            if (!subGoals.contains(subGoal)) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_BELONG_TO_GOAL);
-            }
-            return subGoalConverter.toSubGoalResponseDTO(subGoal);
-
-        } catch (SubGoalException e) {
-          throw e;
-        } catch (Exception e) {
-          log.error("소목표 단건 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-          throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
-        }
-    }
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceImpl.java
@@ -31,9 +31,10 @@ public class SubGoalServiceImpl implements SubGoalService {
       }
 
       SubGoal subGoal = subGoalRepositoryFacade.findSubGoalBySubGoalId(subGoalId);
-      SubGoal updatedSubGoal = subGoalConverter.toSubGoalEntity(subGoal, requestDTO);
+      subGoal.updateFrom(requestDTO);
 
-      return SubGoalConverter.toSubGoalUpdateResponseDTO(updatedSubGoal);
+      return SubGoalConverter.toSubGoalUpdateResponseDTO(
+          subGoalRepositoryFacade.findSubGoalBySubGoalId(subGoalId));
     } catch (SubGoalException e) {
       throw e;
     } catch (Exception e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
@@ -11,11 +11,18 @@ import com.hotpack.krocs.domain.templates.service.TemplateService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @Slf4j
@@ -24,76 +31,78 @@ import java.util.List;
 @RequestMapping("/api/v1/templates")
 public class TemplateController {
 
-    private final TemplateService templateService;
+  private final TemplateService templateService;
 
-    @Operation(summary = "템플릿 생성", description = "title, priority, duration을 설정해 템플릿을 생성합니다.")
-    @PostMapping
-    public ApiResponse<TemplateCreateResponseDTO> createTemplate(
-            @Valid @RequestBody TemplateCreateRequestDTO requestDTO,
-            @RequestParam(value = "user_id", required = false) Long userId
-    ) {
-        try{
-            TemplateCreateResponseDTO responseDTO = templateService.createTemplate(requestDTO, userId);
-            return ApiResponse.success(responseDTO);
+  @Operation(summary = "템플릿 생성", description = "title, priority, duration을 설정해 템플릿을 생성합니다.")
+  @PostMapping
+  public ApiResponse<TemplateCreateResponseDTO> createTemplate(
+      @Valid @RequestBody TemplateCreateRequestDTO requestDTO,
+      @RequestParam(value = "user_id", required = false) Long userId
+  ) {
+    try {
+      TemplateCreateResponseDTO responseDTO = templateService.createTemplate(requestDTO, userId);
+      return ApiResponse.success(responseDTO);
 
-        } catch (TemplateException e){
-            throw  e;
+    } catch (TemplateException e) {
+      throw e;
 
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_CREATION_FAILED);
-        }
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_CREATION_FAILED);
     }
+  }
 
-    @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
-    @GetMapping
-    public ApiResponse<List<TemplateResponseDTO>> getTemplates(
-            @RequestParam(value = "user_id") Long userId,
-            @RequestParam(required = false) String title) {
-        try {
-            List<TemplateResponseDTO> responseDTO = templateService.getTemplatesByUserAndTitle(userId, title);
-            return ApiResponse.success(responseDTO);
+  @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
+  @GetMapping
+  public ApiResponse<List<TemplateResponseDTO>> getTemplates(
+      @RequestParam(value = "user_id") Long userId,
+      @RequestParam(required = false) String title) {
+    try {
+      List<TemplateResponseDTO> responseDTO = templateService.getTemplatesByUserAndTitle(userId,
+          title);
+      return ApiResponse.success(responseDTO);
 
-        } catch (TemplateException e) {
-            throw e;
+    } catch (TemplateException e) {
+      throw e;
 
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
-        }
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
     }
+  }
 
 
-    @Operation(summary = "템플릿 수정", description = "탬플릿을 id 기준으로 수정합니다.")
-    @PatchMapping("/{template_id}")
-    public ApiResponse<TemplateResponseDTO> getTemplates(
-            @PathVariable(value = "template_id") Long templateId,
-            @RequestParam(value = "user_id") Long userId,
-            @RequestBody TemplateUpdateRequestDTO requestDTO){
-        try {
-            TemplateResponseDTO responseDTO = templateService.updateTemplate(templateId, userId, requestDTO);
-            return ApiResponse.success(responseDTO);
+  @Operation(summary = "템플릿 수정", description = "탬플릿을 id 기준으로 수정합니다.")
+  @PatchMapping("/{template_id}")
+  public ApiResponse<TemplateResponseDTO> updateTemplates(
+      @PathVariable(value = "template_id") Long templateId,
+      @RequestParam(value = "user_id") Long userId,
+      @RequestBody TemplateUpdateRequestDTO requestDTO) {
+    try {
+      TemplateResponseDTO responseDTO = templateService.updateTemplate(templateId, userId,
+          requestDTO);
+      return ApiResponse.success(responseDTO);
 
-        } catch (TemplateException e) {
-            throw e;
+    } catch (TemplateException e) {
+      throw e;
 
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_UPDATE_FAILED);
-        }
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_UPDATE_FAILED);
     }
+  }
 
-    @Operation(summary = "템플릿 삭제", description = "템플릿을 탬플릿ID로 삭제합니다.")
-    @DeleteMapping("/{template_id}")
-    public ApiResponse<Void> deleteTemplate(
-            @PathVariable(value = "template_id") Long templateId,
-            @RequestParam(value = "user_id") Long userId) {
-        try {
-            templateService.deleteTemplate(templateId, userId);
-            return ApiResponse.success(null);
+  @Operation(summary = "템플릿 삭제", description = "템플릿을 탬플릿ID로 삭제합니다.")
+  @DeleteMapping("/{template_id}")
+  public ApiResponse<Void> deleteTemplate(
+      @PathVariable(value = "template_id") Long templateId,
+      @RequestParam(value = "user_id") Long userId) {
+    try {
+      templateService.deleteTemplate(templateId, userId);
+      return ApiResponse.success(null);
 
-        } catch (TemplateException e) {
-            throw e;
+    } catch (TemplateException e) {
+      throw e;
 
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_DELETE_FAILED);
-        }
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_DELETE_FAILED);
     }
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/TemplateConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/TemplateConverter.java
@@ -3,94 +3,72 @@ package com.hotpack.krocs.domain.templates.converter;
 import com.hotpack.krocs.domain.templates.domain.SubTemplate;
 import com.hotpack.krocs.domain.templates.domain.Template;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateCreateRequestDTO;
-import com.hotpack.krocs.domain.templates.dto.request.TemplateUpdateRequestDTO;
-import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
+import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateResponseDTO;
 import com.hotpack.krocs.global.common.entity.Priority;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
 
 @Component
 public class TemplateConverter {
 
-    public Template toEntity(TemplateCreateRequestDTO requestDTO) {
+  public Template toEntity(TemplateCreateRequestDTO requestDTO) {
 
-        Priority priority = requestDTO.getPriority();
-        if(requestDTO.getPriority() == null){
-            priority = Priority.MEDIUM;
-        }
-        return Template.builder()
-                .title(requestDTO.getTitle())
-                .priority(priority)
-                .duration(requestDTO.getDuration())
-                .subTemplates(List.of()) // 초기 생성 시 빈 리스트 (추후 추가 가능)
-                .build();
+    Priority priority = requestDTO.getPriority();
+    if (requestDTO.getPriority() == null) {
+      priority = Priority.MEDIUM;
+    }
+    return Template.builder()
+        .title(requestDTO.getTitle())
+        .priority(priority)
+        .duration(requestDTO.getDuration())
+        .subTemplates(List.of()) // 초기 생성 시 빈 리스트 (추후 추가 가능)
+        .build();
+  }
+
+  public TemplateCreateResponseDTO toCreateResponseDTO(Template template) {
+    List<SubTemplateResponseDTO> subTemplateDTOs;
+
+    if (template.getSubTemplates() != null) {
+      subTemplateDTOs = template.getSubTemplates().stream()
+          .map(this::toSubTemplateResponseDTO)
+          .collect(Collectors.toList());
+    } else {
+      subTemplateDTOs = List.of();
     }
 
-    public Template toEntityUpdate(Template existedTemplate, TemplateUpdateRequestDTO requestDTO) {
+    return TemplateCreateResponseDTO.builder()
+        .templateId(template.getTemplateId())
+        .title(template.getTitle())
+        .priority(template.getPriority())
+        .duration(template.getDuration())
+        .subTemplates(subTemplateDTOs)
+        .createdAt(template.getCreatedAt())
+        .updatedAt(template.getUpdatedAt())
+        .build();
+  }
 
-        String title = existedTemplate.getTitle();
-        if (requestDTO.getTitle() != null){ title = requestDTO.getTitle(); }
-
-        Integer duration = existedTemplate.getDuration();
-        if (requestDTO.getDuration() != null){ duration = requestDTO.getDuration(); }
-
-        Priority priority = existedTemplate.getPriority();
-        if (requestDTO.getPriority() != null){ priority = requestDTO.getPriority(); }
-
-        return Template.builder()
-                .templateId(existedTemplate.getTemplateId())
-                .title(title)
-                .duration(duration)
-                .priority(priority)
-                .subTemplates(existedTemplate.getSubTemplates())
-                .build();
-    }
-
-    public TemplateCreateResponseDTO toCreateResponseDTO(Template template) {
-        List<SubTemplateResponseDTO> subTemplateDTOs;
-
-        if (template.getSubTemplates() != null) {
-            subTemplateDTOs = template.getSubTemplates().stream()
-                    .map(this::toSubTemplateResponseDTO)
-                    .collect(Collectors.toList());
-        } else {
-            subTemplateDTOs = List.of();
-        }
-
-        return TemplateCreateResponseDTO.builder()
-                .templateId(template.getTemplateId())
-                .title(template.getTitle())
-                .priority(template.getPriority())
-                .duration(template.getDuration())
-                .subTemplates(subTemplateDTOs)
-                .createdAt(template.getCreatedAt())
-                .updatedAt(template.getUpdatedAt())
-                .build();
-    }
-
-    private SubTemplateResponseDTO toSubTemplateResponseDTO(SubTemplate subTemplate) {
-        return SubTemplateResponseDTO.builder()
-                .subTemplateId(subTemplate.getSubTemplateId())
-                .title(subTemplate.getTitle())
-                .build();
-    }
+  private SubTemplateResponseDTO toSubTemplateResponseDTO(SubTemplate subTemplate) {
+    return SubTemplateResponseDTO.builder()
+        .subTemplateId(subTemplate.getSubTemplateId())
+        .title(subTemplate.getTitle())
+        .build();
+  }
 
 
-    public TemplateResponseDTO toTemplateResponseDTO(Template template) {
-        return TemplateResponseDTO.builder()
-                .templateId(template.getTemplateId())
-                .title(template.getTitle())
-                .priority(template.getPriority())
-                .duration(template.getDuration())
-                .createdAt(template.getCreatedAt())
-                .updatedAt(template.getUpdatedAt())
-                .subTemplates(template.getSubTemplates().stream()
-                        .map(this::toSubTemplateResponseDTO)
-                        .toList())
-                .build();
-    }
+  public TemplateResponseDTO toTemplateResponseDTO(Template template) {
+    return TemplateResponseDTO.builder()
+        .templateId(template.getTemplateId())
+        .title(template.getTitle())
+        .priority(template.getPriority())
+        .duration(template.getDuration())
+        .createdAt(template.getCreatedAt())
+        .updatedAt(template.getUpdatedAt())
+        .subTemplates(template.getSubTemplates().stream()
+            .map(this::toSubTemplateResponseDTO)
+            .toList())
+        .build();
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/domain/Template.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/domain/Template.java
@@ -1,13 +1,24 @@
 package com.hotpack.krocs.domain.templates.domain;
 
+import com.hotpack.krocs.domain.templates.dto.request.TemplateUpdateRequestDTO;
 import com.hotpack.krocs.global.common.entity.BaseTimeEntity;
 import com.hotpack.krocs.global.common.entity.Priority;
-import com.hotpack.krocs.global.common.entity.RepeatType;
-import jakarta.persistence.*;
-import lombok.*;
-
-import java.time.LocalDateTime;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "templates")
@@ -17,22 +28,38 @@ import java.util.List;
 @Builder
 public class Template extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "template_id")
-    private Long templateId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "template_id")
+  private Long templateId;
 
-    @Column(name = "title", nullable = false, length = 200)
-    private String title;
+  @Column(name = "title", nullable = false, length = 200)
+  private String title;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "priority", nullable = false, length = 10)
-    @Builder.Default
-    private Priority priority = Priority.MEDIUM;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "priority", nullable = false, length = 10)
+  @Builder.Default
+  private Priority priority = Priority.MEDIUM;
 
-    @Column(name = "duration", nullable = false)
-    private Integer duration;
+  @Column(name = "duration", nullable = false)
+  private Integer duration;
 
-    @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<SubTemplate> subTemplates;
+  @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private List<SubTemplate> subTemplates;
+
+  public void updateFrom(TemplateUpdateRequestDTO requestDTO) {
+
+    if (requestDTO.getTitle() != null) {
+      this.title = requestDTO.getTitle();
+    }
+
+    if (requestDTO.getDuration() != null) {
+      this.duration = requestDTO.getDuration();
+    }
+
+    if (requestDTO.getPriority() != null) {
+      this.priority = requestDTO.getPriority();
+    }
+    
+  }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
@@ -11,13 +11,12 @@ import com.hotpack.krocs.domain.templates.exception.TemplateException;
 import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
 import com.hotpack.krocs.domain.templates.validator.TemplateValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -25,83 +24,87 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class TemplateServiceImpl implements TemplateService {
 
-    private final TemplateRepositoryFacade templateRepositoryFacade;
-    private final TemplateConverter templateConverter;
-    private final TemplateValidator templateValidator;
+  private final TemplateRepositoryFacade templateRepositoryFacade;
+  private final TemplateConverter templateConverter;
+  private final TemplateValidator templateValidator;
 
 
-    @Override
-    @Transactional
-    public TemplateCreateResponseDTO createTemplate(TemplateCreateRequestDTO requestDTO, Long userId) {
-        try {
+  @Override
+  @Transactional
+  public TemplateCreateResponseDTO createTemplate(TemplateCreateRequestDTO requestDTO,
+      Long userId) {
+    try {
 
-            // 이후에 비즈니스 적용으로 삭제
-            templateValidator.validateTemplateCreateDTO(requestDTO);
-            Template template = templateConverter.toEntity(requestDTO);
-            // templateValidator.validateTemplateBusiness(template); 유효성 검사 적용 이후
-            templateRepositoryFacade.existsByTemplateTitle(template.getTitle());
-            Template savedTemplate = templateRepositoryFacade.save(template);
+      // 이후에 비즈니스 적용으로 삭제
+      templateValidator.validateTemplateCreateDTO(requestDTO);
+      Template template = templateConverter.toEntity(requestDTO);
+      // templateValidator.validateTemplateBusiness(template); 유효성 검사 적용 이후
+      templateRepositoryFacade.existsByTemplateTitle(template.getTitle());
+      Template savedTemplate = templateRepositoryFacade.save(template);
 
-            return templateConverter.toCreateResponseDTO(savedTemplate);
-        } catch (TemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_CREATION_FAILED);
-        }
+      return templateConverter.toCreateResponseDTO(savedTemplate);
+    } catch (TemplateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_CREATION_FAILED);
     }
+  }
 
-    @Override
-    public List<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title) {
-        try {
-            List<Template> templates;
+  @Override
+  public List<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title) {
+    try {
+      List<Template> templates;
 
-            if (StringUtils.hasText(title) && title.length() <= 200) {
-                templates = templateRepositoryFacade.findByTitle(title);
-            } else {
-                templates = templateRepositoryFacade.findAll();
-            }
+      if (StringUtils.hasText(title) && title.length() <= 200) {
+        templates = templateRepositoryFacade.findByTitle(title);
+      } else {
+        templates = templateRepositoryFacade.findAll();
+      }
 
-            return templates.stream()
-                    .map(templateConverter::toTemplateResponseDTO)
-                    .toList();
-        } catch (TemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
-        }
+      return templates.stream()
+          .map(templateConverter::toTemplateResponseDTO)
+          .toList();
+    } catch (TemplateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
     }
+  }
 
-    @Override
-    @Transactional
-    public TemplateResponseDTO updateTemplate(Long templateId, Long userId, TemplateUpdateRequestDTO requestDTO) {
-        try {
-            templateValidator.validateTemplateUpdateDTO(requestDTO);
+  @Override
+  @Transactional
+  public TemplateResponseDTO updateTemplate(Long templateId, Long userId,
+      TemplateUpdateRequestDTO requestDTO) {
+    try {
+      templateValidator.validateTemplateUpdateDTO(requestDTO);
 
-            Template template = templateRepositoryFacade.findByTemplateId(templateId);
+      Template template = templateRepositoryFacade.findByTemplateId(templateId);
 
-            if (requestDTO.getTitle() != null) {
-                templateRepositoryFacade.existsByTemplateTitle(requestDTO.getTitle());
-            }
-            Template tempTemplate = templateConverter.toEntityUpdate(template, requestDTO);
-            Template updatedTemplate = templateRepositoryFacade.update(tempTemplate);
-            return templateConverter.toTemplateResponseDTO(updatedTemplate);
-        } catch (TemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_UPDATE_FAILED);
-        }
+      if (requestDTO.getTitle() != null) {
+        templateRepositoryFacade.existsByTemplateTitle(requestDTO.getTitle());
+      }
+
+      template.updateFrom(requestDTO);
+      Template updatedTemplate = templateRepositoryFacade.findByTemplateId(templateId);
+
+      return templateConverter.toTemplateResponseDTO(updatedTemplate);
+    } catch (TemplateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_UPDATE_FAILED);
     }
+  }
 
-    @Override
-    @Transactional
-    public void deleteTemplate(Long templateId, Long userId) {
-        try {
-            Template template = templateRepositoryFacade.findByTemplateId(templateId);
-            templateRepositoryFacade.delete(template);
-        } catch (TemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_DELETE_FAILED);
-        }
+  @Override
+  @Transactional
+  public void deleteTemplate(Long templateId, Long userId) {
+    try {
+      Template template = templateRepositoryFacade.findByTemplateId(templateId);
+      templateRepositoryFacade.delete(template);
+    } catch (TemplateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new TemplateException(TemplateExceptionType.TEMPLATE_DELETE_FAILED);
     }
+  }
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/converter/GoalConvertorTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/converter/GoalConvertorTest.java
@@ -1,356 +1,302 @@
 package com.hotpack.krocs.domain.goals.converter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.global.common.entity.Priority;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class GoalConvertorTest {
 
-    private GoalConverter goalConvertor;
+  private GoalConverter goalConvertor;
 
-    private GoalCreateRequestDTO validRequestDTO;
-    private Goal validGoal;
-    private Goal existingGoal;
+  private GoalCreateRequestDTO validRequestDTO;
+  private Goal validGoal;
+  private Goal existingGoal;
 
-    @BeforeEach
-    void setUp() {
-        goalConvertor = new GoalConverter();
+  @BeforeEach
+  void setUp() {
+    goalConvertor = new GoalConverter();
 
-        validRequestDTO = GoalCreateRequestDTO.builder()
-                .title("테스트 목표")
-                .priority(Priority.HIGH)
-                .startDate(LocalDate.of(2024, 1, 1))
-                .endDate(LocalDate.of(2024, 12, 31))
-                .duration(365)
-                .build();
+    validRequestDTO = GoalCreateRequestDTO.builder()
+        .title("테스트 목표")
+        .priority(Priority.HIGH)
+        .startDate(LocalDate.of(2024, 1, 1))
+        .endDate(LocalDate.of(2024, 12, 31))
+        .duration(365)
+        .build();
 
-        validGoal = Goal.builder()
-                .goalId(1L)
-                .title("테스트 목표")
-                .priority(Priority.HIGH)
-                .startDate(LocalDate.of(2024, 1, 1))
-                .endDate(LocalDate.of(2024, 12, 31))
-                .duration(365)
-                .isCompleted(false)
-                .build();
+    validGoal = Goal.builder()
+        .goalId(1L)
+        .title("테스트 목표")
+        .priority(Priority.HIGH)
+        .startDate(LocalDate.of(2024, 1, 1))
+        .endDate(LocalDate.of(2024, 12, 31))
+        .duration(365)
+        .isCompleted(false)
+        .build();
 
-        existingGoal = Goal.builder()
-                .goalId(1L)
-                .title("기존 제목")
-                .priority(Priority.MEDIUM)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusDays(7))
-                .duration(7)
-                .isCompleted(false)
-                .build();
-    }
+    existingGoal = Goal.builder()
+        .goalId(1L)
+        .title("기존 제목")
+        .priority(Priority.MEDIUM)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusDays(7))
+        .duration(7)
+        .isCompleted(false)
+        .build();
+  }
 
-    // ========== CreateGoalRequestDTO 변환 테스트 ==========
+  // ========== CreateGoalRequestDTO 변환 테스트 ==========
 
-    @Test
-    @DisplayName("CreateGoalRequestDTO를 Goal 엔티티로 변환")
-    void toEntity_Success() {
-        // when
-        Goal result = goalConvertor.toEntity(validRequestDTO);
+  @Test
+  @DisplayName("CreateGoalRequestDTO를 Goal 엔티티로 변환")
+  void toEntity_Success() {
+    // when
+    Goal result = goalConvertor.toEntity(validRequestDTO);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("테스트 목표");
-        assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
-        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
-        assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2024, 12, 31));
-        assertThat(result.getDuration()).isEqualTo(365);
-        assertThat(result.getIsCompleted()).isFalse();
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("테스트 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+    assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+    assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2024, 12, 31));
+    assertThat(result.getDuration()).isEqualTo(365);
+    assertThat(result.getIsCompleted()).isFalse();
+  }
 
-    @Test
-    @DisplayName("Goal 엔티티를 GoalCreateResponseDTO로 변환")
-    void toCreateResponseDTO_Success() {
-        // when
-        GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(validGoal);
+  @Test
+  @DisplayName("Goal 엔티티를 GoalCreateResponseDTO로 변환")
+  void toCreateResponseDTO_Success() {
+    // when
+    GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(validGoal);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getTitle()).isEqualTo("테스트 목표");
-        assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
-        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
-        assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2024, 12, 31));
-        assertThat(result.getDuration()).isEqualTo(365);
-        assertThat(result.isCompleted()).isFalse();
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(1L);
+    assertThat(result.getTitle()).isEqualTo("테스트 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+    assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+    assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2024, 12, 31));
+    assertThat(result.getDuration()).isEqualTo(365);
+    assertThat(result.isCompleted()).isFalse();
+  }
 
-    @Test
-    @DisplayName("최소 데이터로 DTO를 엔티티로 변환")
-    void toEntity_MinimalData() {
-        // given
-        GoalCreateRequestDTO minimalRequest = GoalCreateRequestDTO.builder()
-                .title("최소 목표")
-                .duration(1)
-                .build();
+  @Test
+  @DisplayName("최소 데이터로 DTO를 엔티티로 변환")
+  void toEntity_MinimalData() {
+    // given
+    GoalCreateRequestDTO minimalRequest = GoalCreateRequestDTO.builder()
+        .title("최소 목표")
+        .duration(1)
+        .build();
 
-        // when
-        Goal result = goalConvertor.toEntity(minimalRequest);
+    // when
+    Goal result = goalConvertor.toEntity(minimalRequest);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("최소 목표");
-        assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM); // 기본값
-        assertThat(result.getStartDate()).isNull();
-        assertThat(result.getEndDate()).isNull();
-        assertThat(result.getDuration()).isEqualTo(1);
-        assertThat(result.getIsCompleted()).isFalse();
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("최소 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM); // 기본값
+    assertThat(result.getStartDate()).isNull();
+    assertThat(result.getEndDate()).isNull();
+    assertThat(result.getDuration()).isEqualTo(1);
+    assertThat(result.getIsCompleted()).isFalse();
+  }
 
-    @Test
-    @DisplayName("null 값이 포함된 DTO를 엔티티로 변환")
-    void toEntity_WithNullValues() {
-        // given
-        GoalCreateRequestDTO requestWithNulls = GoalCreateRequestDTO.builder()
-                .title("null 테스트")
-                .priority(null)
-                .startDate(null)
-                .endDate(null)
-                .duration(30)
-                .build();
+  @Test
+  @DisplayName("null 값이 포함된 DTO를 엔티티로 변환")
+  void toEntity_WithNullValues() {
+    // given
+    GoalCreateRequestDTO requestWithNulls = GoalCreateRequestDTO.builder()
+        .title("null 테스트")
+        .priority(null)
+        .startDate(null)
+        .endDate(null)
+        .duration(30)
+        .build();
 
-        // when
-        Goal result = goalConvertor.toEntity(requestWithNulls);
+    // when
+    Goal result = goalConvertor.toEntity(requestWithNulls);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("null 테스트");
-        assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM); // 기본값
-        assertThat(result.getStartDate()).isNull();
-        assertThat(result.getEndDate()).isNull();
-        assertThat(result.getDuration()).isEqualTo(30);
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("null 테스트");
+    assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM); // 기본값
+    assertThat(result.getStartDate()).isNull();
+    assertThat(result.getEndDate()).isNull();
+    assertThat(result.getDuration()).isEqualTo(30);
+  }
 
-    @Test
-    @DisplayName("완료된 목표를 응답 DTO로 변환")
-    void toCreateResponseDTO_CompletedGoal() {
-        // given
-        Goal completedGoal = Goal.builder()
-                .goalId(1L)
-                .title("완료된 목표")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(true)
-                .build();
+  @Test
+  @DisplayName("완료된 목표를 응답 DTO로 변환")
+  void toCreateResponseDTO_CompletedGoal() {
+    // given
+    Goal completedGoal = Goal.builder()
+        .goalId(1L)
+        .title("완료된 목표")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(true)
+        .build();
 
-        // when
-        GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(completedGoal);
+    // when
+    GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(completedGoal);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getTitle()).isEqualTo("완료된 목표");
-        assertThat(result.isCompleted()).isTrue();
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(1L);
+    assertThat(result.getTitle()).isEqualTo("완료된 목표");
+    assertThat(result.isCompleted()).isTrue();
+  }
 
-    @Test
-    @DisplayName("null 값이 포함된 Goal을 응답 DTO로 변환")
-    void toCreateResponseDTO_WithNullValues() {
-        // given
-        Goal goalWithNulls = Goal.builder()
-                .goalId(1L)
-                .title("null 테스트")
-                .priority(null)
-                .startDate(null)
-                .endDate(null)
-                .duration(30)
-                .isCompleted(false)
-                .build();
+  @Test
+  @DisplayName("null 값이 포함된 Goal을 응답 DTO로 변환")
+  void toCreateResponseDTO_WithNullValues() {
+    // given
+    Goal goalWithNulls = Goal.builder()
+        .goalId(1L)
+        .title("null 테스트")
+        .priority(null)
+        .startDate(null)
+        .endDate(null)
+        .duration(30)
+        .isCompleted(false)
+        .build();
 
-        // when
-        GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(goalWithNulls);
+    // when
+    GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(goalWithNulls);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getTitle()).isEqualTo("null 테스트");
-        assertThat(result.getPriority()).isNull();
-        assertThat(result.getStartDate()).isNull();
-        assertThat(result.getEndDate()).isNull();
-        assertThat(result.getDuration()).isEqualTo(30);
-        assertThat(result.isCompleted()).isFalse();
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(1L);
+    assertThat(result.getTitle()).isEqualTo("null 테스트");
+    assertThat(result.getPriority()).isNull();
+    assertThat(result.getStartDate()).isNull();
+    assertThat(result.getEndDate()).isNull();
+    assertThat(result.getDuration()).isEqualTo(30);
+    assertThat(result.isCompleted()).isFalse();
+  }
 
-    // ========== UpdateGoalRequestDTO 변환 테스트 ==========
+  // ========== toGoalResponseDTO 테스트 ==========
 
-    @Test
-    @DisplayName("UpdateGoalRequestDTO를 Goal 엔티티로 변환")
-    void toEntity_UpdateRequest_Success() {
-        // given
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("수정된 목표")
-                .priority(Priority.LOW)
-                .startDate(LocalDate.of(2025, 6, 1))
-                .endDate(LocalDate.of(2025, 6, 30))
-                .duration(30)
-                .build();
+  @Test
+  @DisplayName("Goal 엔티티를 GoalResponseDTO로 변환")
+  void toGoalResponseDTO_Success() {
+    // given
+    Goal goal = Goal.builder()
+        .goalId(2L)
+        .title("GoalResponseDTO 테스트")
+        .priority(Priority.CRITICAL)
+        .startDate(LocalDate.of(2025, 8, 1))
+        .endDate(LocalDate.of(2025, 8, 31))
+        .duration(31)
+        .isCompleted(true)
+        .build();
 
-        // when
-        Goal result = goalConvertor.toEntity(existingGoal, updateRequest);
+    // when
+    GoalResponseDTO result = goalConvertor.toGoalResponseDTO(goal);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("수정된 목표");
-        assertThat(result.getPriority()).isEqualTo(Priority.LOW);
-        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2025, 6, 1));
-        assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2025, 6, 30));
-        assertThat(result.getDuration()).isEqualTo(30);
-        assertThat(result.getIsCompleted()).isFalse();
-    }
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(2L);
+    assertThat(result.getTitle()).isEqualTo("GoalResponseDTO 테스트");
+    assertThat(result.getPriority()).isEqualTo(Priority.CRITICAL);
+    assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2025, 8, 1));
+    assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2025, 8, 31));
+    assertThat(result.getDuration()).isEqualTo(31);
+    assertThat(result.getIsCompleted()).isTrue();
+    assertThat(result.getCompletionPercentage()).isEqualTo(100);
+  }
 
-    @Test
-    @DisplayName("UpdateGoalRequestDTO 부분 변환 - null 필드들")
-    void toEntity_UpdateRequest_PartialData() {
-        // given
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("부분 수정")
-                .priority(null)
-                .startDate(null)
-                .endDate(null)
-                .duration(null)
-                .build();
+  @Test
+  @DisplayName("List<Goal>을 List<GoalResponseDTO>로 변환")
+  void toGoalResponseDTO_List_Success() {
+    // given
+    Goal goal1 = Goal.builder()
+        .goalId(1L)
+        .title("목표 1")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(false)
+        .build();
 
-        // when
-        Goal result = goalConvertor.toEntity(existingGoal, updateRequest);
+    Goal goal2 = Goal.builder()
+        .goalId(2L)
+        .title("목표 2")
+        .priority(Priority.LOW)
+        .duration(60)
+        .isCompleted(true)
+        .build();
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("부분 수정");
-        assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM);
-        assertThat(result.getStartDate()).isEqualTo(LocalDate.now());
-        assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(7));
-        assertThat(result.getDuration()).isEqualTo(7);
-        assertThat(result.getIsCompleted()).isFalse();
-    }
+    List<Goal> goals = Arrays.asList(goal1, goal2);
 
-    // ========== toGoalResponseDTO 테스트 ==========
+    // when
+    List<GoalResponseDTO> result = goalConvertor.toGoalResponseDTO(goals);
 
-    @Test
-    @DisplayName("Goal 엔티티를 GoalResponseDTO로 변환")
-    void toGoalResponseDTO_Success() {
-        // given
-        Goal goal = Goal.builder()
-                .goalId(2L)
-                .title("GoalResponseDTO 테스트")
-                .priority(Priority.CRITICAL)
-                .startDate(LocalDate.of(2025, 8, 1))
-                .endDate(LocalDate.of(2025, 8, 31))
-                .duration(31)
-                .isCompleted(true)
-                .build();
+    // then
+    assertThat(result).hasSize(2);
 
-        // when
-        GoalResponseDTO result = goalConvertor.toGoalResponseDTO(goal);
+    // 첫 번째 목표 검증
+    GoalResponseDTO firstResult = result.get(0);
+    assertThat(firstResult.getGoalId()).isEqualTo(1L);
+    assertThat(firstResult.getTitle()).isEqualTo("목표 1");
+    assertThat(firstResult.getPriority()).isEqualTo(Priority.HIGH);
+    assertThat(firstResult.getIsCompleted()).isFalse();
+    assertThat(firstResult.getCompletionPercentage()).isEqualTo(0);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getGoalId()).isEqualTo(2L);
-        assertThat(result.getTitle()).isEqualTo("GoalResponseDTO 테스트");
-        assertThat(result.getPriority()).isEqualTo(Priority.CRITICAL);
-        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2025, 8, 1));
-        assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2025, 8, 31));
-        assertThat(result.getDuration()).isEqualTo(31);
-        assertThat(result.getIsCompleted()).isTrue();
-        assertThat(result.getCompletionPercentage()).isEqualTo(100);
-    }
+    // 두 번째 목표 검증
+    GoalResponseDTO secondResult = result.get(1);
+    assertThat(secondResult.getGoalId()).isEqualTo(2L);
+    assertThat(secondResult.getTitle()).isEqualTo("목표 2");
+    assertThat(secondResult.getPriority()).isEqualTo(Priority.LOW);
+    assertThat(secondResult.getIsCompleted()).isTrue();
+    assertThat(secondResult.getCompletionPercentage()).isEqualTo(100);
+  }
 
-    @Test
-    @DisplayName("List<Goal>을 List<GoalResponseDTO>로 변환")
-    void toGoalResponseDTO_List_Success() {
-        // given
-        Goal goal1 = Goal.builder()
-                .goalId(1L)
-                .title("목표 1")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(false)
-                .build();
+  @Test
+  @DisplayName("빈 Goal 리스트를 빈 GoalResponseDTO 리스트로 변환")
+  void toGoalResponseDTO_EmptyList() {
+    // given
+    List<Goal> emptyGoals = Collections.emptyList();
 
-        Goal goal2 = Goal.builder()
-                .goalId(2L)
-                .title("목표 2")
-                .priority(Priority.LOW)
-                .duration(60)
-                .isCompleted(true)
-                .build();
+    // when
+    List<GoalResponseDTO> result = goalConvertor.toGoalResponseDTO(emptyGoals);
 
-        List<Goal> goals = Arrays.asList(goal1, goal2);
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).isEmpty();
+  }
 
-        // when
-        List<GoalResponseDTO> result = goalConvertor.toGoalResponseDTO(goals);
+  // ========== 날짜/시간 필드 테스트 ==========
 
-        // then
-        assertThat(result).hasSize(2);
+  @Test
+  @DisplayName("null createdAt, updatedAt 필드 처리")
+  void dateTimeFields_Null() {
+    // given
+    Goal goalWithNullDates = Goal.builder()
+        .goalId(1L)
+        .title("null 날짜 테스트")
+        .priority(Priority.LOW)
+        .duration(30)
+        .isCompleted(false)
+        .build();
+    // createdAt, updatedAt는 null로 남겨둠
 
-        // 첫 번째 목표 검증
-        GoalResponseDTO firstResult = result.get(0);
-        assertThat(firstResult.getGoalId()).isEqualTo(1L);
-        assertThat(firstResult.getTitle()).isEqualTo("목표 1");
-        assertThat(firstResult.getPriority()).isEqualTo(Priority.HIGH);
-        assertThat(firstResult.getIsCompleted()).isFalse();
-        assertThat(firstResult.getCompletionPercentage()).isEqualTo(0);
+    // when
+    GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(goalWithNullDates);
 
-        // 두 번째 목표 검증
-        GoalResponseDTO secondResult = result.get(1);
-        assertThat(secondResult.getGoalId()).isEqualTo(2L);
-        assertThat(secondResult.getTitle()).isEqualTo("목표 2");
-        assertThat(secondResult.getPriority()).isEqualTo(Priority.LOW);
-        assertThat(secondResult.getIsCompleted()).isTrue();
-        assertThat(secondResult.getCompletionPercentage()).isEqualTo(100);
-    }
-
-    @Test
-    @DisplayName("빈 Goal 리스트를 빈 GoalResponseDTO 리스트로 변환")
-    void toGoalResponseDTO_EmptyList() {
-        // given
-        List<Goal> emptyGoals = Collections.emptyList();
-
-        // when
-        List<GoalResponseDTO> result = goalConvertor.toGoalResponseDTO(emptyGoals);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result).isEmpty();
-    }
-
-    // ========== 날짜/시간 필드 테스트 ==========
-
-    @Test
-    @DisplayName("null createdAt, updatedAt 필드 처리")
-    void dateTimeFields_Null() {
-        // given
-        Goal goalWithNullDates = Goal.builder()
-                .goalId(1L)
-                .title("null 날짜 테스트")
-                .priority(Priority.LOW)
-                .duration(30)
-                .isCompleted(false)
-                .build();
-        // createdAt, updatedAt는 null로 남겨둠
-
-        // when
-        GoalCreateResponseDTO result = goalConvertor.toCreateResponseDTO(goalWithNullDates);
-
-        // then
-        assertThat(result.getCreatedAt()).isNull();
-        assertThat(result.getUpdatedAt()).isNull();
-    }
+    // then
+    assertThat(result.getCreatedAt()).isNull();
+    assertThat(result.getUpdatedAt()).isNull();
+  }
 } 

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -128,7 +128,6 @@ class GoalServiceTest {
         .subGoalId(validSubGoal.getSubGoalId())
         .title(validSubGoal.getTitle())
         .completed(validSubGoal.getIsCompleted())
-        .completionPercentage(0)
         .build();
 
     existingGoal = Goal.builder()
@@ -776,7 +775,6 @@ class GoalServiceTest {
       assertThat(subGoalRequestDTO.getSubGoalId()).isEqualTo(1L);
       assertThat(subGoalRequestDTO.getTitle()).isEqualTo("테스트 소목표1");
       assertThat(subGoalRequestDTO.getCompleted()).isEqualTo(false);
-      assertThat(subGoalRequestDTO.getCompletionPercentage()).isEqualTo(0);
     }
   }
 
@@ -906,8 +904,6 @@ class GoalServiceTest {
     assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getSubGoalId()).isEqualTo(1L);
     assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getCompleted()).isEqualTo(false);
     assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getTitle()).isEqualTo("테스트 소목표1");
-    assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getCompletionPercentage()).isEqualTo(
-        0);
   }
 
   @Test

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -2,7 +2,12 @@ package com.hotpack.krocs.domain.goals.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hotpack.krocs.domain.goals.converter.GoalConverter;
@@ -10,14 +15,14 @@ import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
@@ -28,6 +33,8 @@ import com.hotpack.krocs.global.common.entity.Priority;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,718 +44,713 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-import java.util.Collections;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class GoalServiceTest {
 
-    @Mock
-    private GoalRepositoryFacade goalRepositoryFacade;
-    @Mock
-    private SubGoalRepositoryFacade subGoalRepositoryFacade;
-    @Mock
-    private SubGoalConverter subGoalConverter;
+  @Mock
+  private GoalRepositoryFacade goalRepositoryFacade;
+  @Mock
+  private SubGoalRepositoryFacade subGoalRepositoryFacade;
+  @Mock
+  private SubGoalConverter subGoalConverter;
 
-    @InjectMocks
-    private GoalServiceImpl goalService;
+  @InjectMocks
+  private GoalServiceImpl goalService;
 
-    private GoalCreateRequestDTO validRequestDTO;
-    private Goal validGoal;
-    private GoalCreateResponseDTO validResponseDTO;
+  private GoalCreateRequestDTO validRequestDTO;
+  private Goal validGoal;
+  private GoalCreateResponseDTO validResponseDTO;
 
-    @Mock
-    private GoalConverter goalConverter;
+  @Mock
+  private GoalConverter goalConverter;
 
-//    private GoalServiceImpl goalService;
-    private GoalValidator goalValidator = new GoalValidator();
+  //    private GoalServiceImpl goalService;
+  private GoalValidator goalValidator = new GoalValidator();
 
-    private Goal existingGoal;
+  private Goal existingGoal;
 
-    private SubGoalCreateRequestDTO validSubGoalCreateRequestDTO;
-    private SubGoal validSubGoal;
-    private SubGoalResponseDTO validSubGoalResponseDTO;
-    private SubGoalRequestDTO validSubGoalRequestDTO;
+  private SubGoalCreateRequestDTO validSubGoalCreateRequestDTO;
+  private SubGoal validSubGoal;
+  private SubGoalResponseDTO validSubGoalResponseDTO;
+  private SubGoalRequestDTO validSubGoalRequestDTO;
 
-    @BeforeEach
-    void setUp() {
-        goalService = new GoalServiceImpl(subGoalRepositoryFacade, subGoalConverter, goalRepositoryFacade, goalConverter, goalValidator);
+  @BeforeEach
+  void setUp() {
+    goalService = new GoalServiceImpl(subGoalRepositoryFacade, subGoalConverter,
+        goalRepositoryFacade, goalConverter, goalValidator);
 
-        validRequestDTO = GoalCreateRequestDTO.builder()
-                .title("테스트 목표")
-                .priority(Priority.HIGH)
-                .startDate(LocalDate.now().plusDays(1))
-                .endDate(LocalDate.now().plusDays(365))
-                .duration(365)
-                .build();
+    validRequestDTO = GoalCreateRequestDTO.builder()
+        .title("테스트 목표")
+        .priority(Priority.HIGH)
+        .startDate(LocalDate.now().plusDays(1))
+        .endDate(LocalDate.now().plusDays(365))
+        .duration(365)
+        .build();
 
-        validGoal = Goal.builder()
-            .goalId(1L)
-            .title("테스트 목표")
-            .priority(Priority.HIGH)
-            .startDate(LocalDate.now().plusDays(1))
-            .endDate(LocalDate.now().plusDays(365))
-            .duration(365)
-            .isCompleted(false)
-            .build();
+    validGoal = Goal.builder()
+        .goalId(1L)
+        .title("테스트 목표")
+        .priority(Priority.HIGH)
+        .startDate(LocalDate.now().plusDays(1))
+        .endDate(LocalDate.now().plusDays(365))
+        .duration(365)
+        .isCompleted(false)
+        .build();
 
-        validResponseDTO = GoalCreateResponseDTO.builder()
-            .goalId(1L)
-            .title("테스트 목표")
-            .priority(Priority.HIGH)
-            .startDate(LocalDate.now().plusDays(1))
-            .endDate(LocalDate.now().plusDays(365))
-            .duration(365)
-            .completed(false)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
+    validResponseDTO = GoalCreateResponseDTO.builder()
+        .goalId(1L)
+        .title("테스트 목표")
+        .priority(Priority.HIGH)
+        .startDate(LocalDate.now().plusDays(1))
+        .endDate(LocalDate.now().plusDays(365))
+        .duration(365)
+        .completed(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
 
-        validSubGoalRequestDTO = SubGoalRequestDTO.builder()
-            .title("테스트 소목표1")
-            .build();
+    validSubGoalRequestDTO = SubGoalRequestDTO.builder()
+        .title("테스트 소목표1")
+        .build();
 
-        validSubGoalCreateRequestDTO = SubGoalCreateRequestDTO.builder()
-            .subGoals(List.of(validSubGoalRequestDTO))
-            .build();
+    validSubGoalCreateRequestDTO = SubGoalCreateRequestDTO.builder()
+        .subGoals(List.of(validSubGoalRequestDTO))
+        .build();
 
-        validSubGoal = SubGoal.builder()
-            .subGoalId(1L)
-            .goal(validGoal)
-            .title("테스트 소목표1")
-            .isCompleted(false)
-            .build();
+    validSubGoal = SubGoal.builder()
+        .subGoalId(1L)
+        .goal(validGoal)
+        .title("테스트 소목표1")
+        .isCompleted(false)
+        .build();
 
-        validSubGoalResponseDTO = SubGoalResponseDTO.builder()
-            .subGoalId(validSubGoal.getSubGoalId())
-            .title(validSubGoal.getTitle())
-            .completed(validSubGoal.getIsCompleted())
-            .completionPercentage(0)
-            .build();
+    validSubGoalResponseDTO = SubGoalResponseDTO.builder()
+        .subGoalId(validSubGoal.getSubGoalId())
+        .title(validSubGoal.getTitle())
+        .completed(validSubGoal.getIsCompleted())
+        .completionPercentage(0)
+        .build();
 
-        existingGoal = Goal.builder()
-                .goalId(1L)
-                .title("기존 제목")  // 원래 제목
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(false)
-                .build();
-    }
+    existingGoal = Goal.builder()
+        .goalId(1L)
+        .title("기존 제목")  // 원래 제목
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(false)
+        .build();
+  }
 
-    // ========== CREATE 테스트 ==========
+  // ========== CREATE 테스트 ==========
 
   @Test
   @DisplayName("대목표 생성 성공 테스트")
   void createGoal_Success() {
-      // given
-      when(goalRepositoryFacade.existsByTitle(validRequestDTO.getTitle())).thenReturn(false);
-      when(goalConverter.toEntity(validRequestDTO)).thenReturn(validGoal);
-      when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
-      when(goalConverter.toCreateResponseDTO(validGoal)).thenReturn(validResponseDTO);
+    // given
+    when(goalRepositoryFacade.existsByTitle(validRequestDTO.getTitle())).thenReturn(false);
+    when(goalConverter.toEntity(validRequestDTO)).thenReturn(validGoal);
+    when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
+    when(goalConverter.toCreateResponseDTO(validGoal)).thenReturn(validResponseDTO);
 
-      // when
-      GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
+    // when
+    GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
 
-      // then
-      assertThat(result).isNotNull();
-      assertThat(result.getGoalId()).isEqualTo(1L);
-      assertThat(result.getTitle()).isEqualTo("테스트 목표");
-      assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(1L);
+    assertThat(result.getTitle()).isEqualTo("테스트 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
   }
 
   @Test
   @DisplayName("대목표 생성 - 제목이 비어있는 경우")
   void createGoal_EmptyTitle() {
-      // given
-      when(goalRepositoryFacade.existsByTitle(validRequestDTO.getTitle())).thenReturn(false);
-      when(goalConverter.toEntity(validRequestDTO)).thenReturn(validGoal);
-      when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
-      when(goalConverter.toCreateResponseDTO(validGoal)).thenReturn(validResponseDTO);
+    // given
+    when(goalRepositoryFacade.existsByTitle(validRequestDTO.getTitle())).thenReturn(false);
+    when(goalConverter.toEntity(validRequestDTO)).thenReturn(validGoal);
+    when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
+    when(goalConverter.toCreateResponseDTO(validGoal)).thenReturn(validResponseDTO);
 
-      // when
-      GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
+    // when
+    GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
 
-      // then
-      assertThat(result).isNotNull();
-      assertThat(result.getGoalId()).isEqualTo(1L);
-      assertThat(result.getTitle()).isEqualTo("테스트 목표");
-      assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(1L);
+    assertThat(result.getTitle()).isEqualTo("테스트 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
   }
 
   @Test
   @DisplayName("대목표 생성 - 제목이 null인 경우")
   void createGoal_NullTitle() {
-      // given
-      GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
-              .title("")
-              .duration(30)
-              .build();
+    // given
+    GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
+        .title("")
+        .duration(30)
+        .build();
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
   }
 
   @Test
   @DisplayName("대목표 생성 - 제목이 공백인 경우")
   void createGoal_BlankTitle() {
-      // given
-      GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
-              .title("   ")
-              .duration(30)
-              .build();
+    // given
+    GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
+        .title("   ")
+        .duration(30)
+        .build();
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
   }
 
   @Test
   @DisplayName("대목표 생성 - 기간이 null인 경우")
   void createGoal_NullDuration() {
-      // given
-      GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
-              .title("테스트 목표")
-              .duration(null)
-              .build();
+    // given
+    GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
+        .title("테스트 목표")
+        .duration(null)
+        .build();
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
   }
 
   @Test
   @DisplayName("대목표 생성 - 기간이 0인 경우")
   void createGoal_ZeroDuration() {
-      // given
-      GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
-              .title("테스트 목표")
-              .duration(0)
-              .build();
+    // given
+    GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
+        .title("테스트 목표")
+        .duration(0)
+        .build();
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
   }
 
   @Test
   @DisplayName("대목표 생성 - 기간이 음수인 경우")
   void createGoal_NegativeDuration() {
-      // given
-      GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
-              .title("테스트 목표")
-              .duration(-1)
-              .build();
+    // given
+    GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
+        .title("테스트 목표")
+        .duration(-1)
+        .build();
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
   }
 
   @Test
   @DisplayName("대목표 생성 - 날짜 범위가 유효하지 않은 경우")
   void createGoal_InvalidDateRange() {
-      // given
-      GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
-              .title("테스트 목표")
-              .startDate(LocalDate.of(2024, 12, 31))
-              .endDate(LocalDate.of(2024, 1, 1))
-              .duration(30)
-              .build();
+    // given
+    GoalCreateRequestDTO invalidRequest = GoalCreateRequestDTO.builder()
+        .title("테스트 목표")
+        .startDate(LocalDate.of(2024, 12, 31))
+        .endDate(LocalDate.of(2024, 1, 1))
+        .duration(30)
+        .build();
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.INVALID_GOAL_DATE_RANGE);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType",
+            GoalExceptionType.INVALID_GOAL_DATE_RANGE);
   }
 
   @Test
   @DisplayName("대목표 생성 - Repository에서 예외 발생")
   void createGoal_RepositoryException() {
-      // given
-      when(goalConverter.toEntity(any())).thenReturn(validGoal);
-      when(goalRepositoryFacade.saveGoal(any())).thenThrow(new RuntimeException("데이터베이스 오류"));
+    // given
+    when(goalConverter.toEntity(any())).thenReturn(validGoal);
+    when(goalRepositoryFacade.saveGoal(any())).thenThrow(new RuntimeException("데이터베이스 오류"));
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_CREATION_FAILED);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_CREATION_FAILED);
   }
 
   @Test
   @DisplayName("대목표 생성 - Convertor에서 예외 발생")
   void createGoal_ConvertorException() {
-      // given
-      when(goalConverter.toEntity(any())).thenThrow(new RuntimeException("변환 오류"));
+    // given
+    when(goalConverter.toEntity(any())).thenThrow(new RuntimeException("변환 오류"));
 
-      // when & then
-      assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
-              .isInstanceOf(GoalException.class)
-              .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_CREATION_FAILED);
+    // when & then
+    assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_CREATION_FAILED);
   }
 
   @Test
   @DisplayName("대목표 생성 - 최소 필수 데이터만으로 성공")
   void createGoal_MinimalData() {
-      // given
-      GoalCreateRequestDTO minimalRequest = GoalCreateRequestDTO.builder()
-              .title("최소 목표")
-              .duration(1)
-              .build();
+    // given
+    GoalCreateRequestDTO minimalRequest = GoalCreateRequestDTO.builder()
+        .title("최소 목표")
+        .duration(1)
+        .build();
 
-      Goal minimalGoal = Goal.builder()
-              .goalId(1L)
-              .title("최소 목표")
-              .priority(Priority.MEDIUM)
-              .duration(1)
-              .isCompleted(false)
-              .build();
+    Goal minimalGoal = Goal.builder()
+        .goalId(1L)
+        .title("최소 목표")
+        .priority(Priority.MEDIUM)
+        .duration(1)
+        .isCompleted(false)
+        .build();
 
-      GoalCreateResponseDTO minimalResponse = GoalCreateResponseDTO.builder()
-              .goalId(1L)
-              .title("최소 목표")
-              .priority(Priority.MEDIUM)
-              .duration(1)
-              .completed(false)
-              .createdAt(LocalDateTime.now())
-              .updatedAt(LocalDateTime.now())
-              .build();
+    GoalCreateResponseDTO minimalResponse = GoalCreateResponseDTO.builder()
+        .goalId(1L)
+        .title("최소 목표")
+        .priority(Priority.MEDIUM)
+        .duration(1)
+        .completed(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
 
-      when(goalConverter.toEntity(minimalRequest)).thenReturn(minimalGoal);
-      when(goalRepositoryFacade.saveGoal(minimalGoal)).thenReturn(minimalGoal);
-      when(goalConverter.toCreateResponseDTO(minimalGoal)).thenReturn(minimalResponse);
+    when(goalConverter.toEntity(minimalRequest)).thenReturn(minimalGoal);
+    when(goalRepositoryFacade.saveGoal(minimalGoal)).thenReturn(minimalGoal);
+    when(goalConverter.toCreateResponseDTO(minimalGoal)).thenReturn(minimalResponse);
 
-      // when
-      GoalCreateResponseDTO result = goalService.createGoal(minimalRequest, 1L);
+    // when
+    GoalCreateResponseDTO result = goalService.createGoal(minimalRequest, 1L);
 
-      // then
-      assertThat(result).isNotNull();
-      assertThat(result.getTitle()).isEqualTo("최소 목표");
-      assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM);
-      assertThat(result.getDuration()).isEqualTo(1);
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("최소 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM);
+    assertThat(result.getDuration()).isEqualTo(1);
   }
 
-    // ========== UPDATE 테스트 ==========
-
-    @Test
-    @DisplayName("목표 수정 성공 - 제목만 수정")
-    void updateGoalById_Success_TitleOnly() {
-        // given
-        Long goalId = 1L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("수정된 제목")
-                .build();
-
-        Goal updatedGoal = Goal.builder()
-                .goalId(1L)
-                .title("수정된 제목")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(false)
-                .build();
-
-        GoalResponseDTO expectedResponse = GoalResponseDTO.builder()
-                .goalId(1L)
-                .title("수정된 제목")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(false)
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-        when(goalRepositoryFacade.existsByTitleAndGoalIdNot("수정된 제목", goalId)).thenReturn(false);
-        when(goalConverter.toEntity(existingGoal, updateRequest)).thenReturn(updatedGoal);
-        when(goalRepositoryFacade.updateGoal(updatedGoal)).thenReturn(updatedGoal);
-        when(goalConverter.toGoalResponseDTO(updatedGoal)).thenReturn(expectedResponse);
-
-        // when
-        GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("수정된 제목");
-        assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
-        assertThat(result.getDuration()).isEqualTo(30);
-    }
-
-    @Test
-    @DisplayName("목표 수정 성공 - 여러 필드 수정")
-    void updateGoalById_Success_MultipleFields() {
-        // given
-        Long goalId = 1L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("수정된 제목")
-                .priority(Priority.LOW)
-                .startDate(LocalDate.of(2025, 8, 1))
-                .endDate(LocalDate.of(2025, 8, 31))
-                .duration(31)
-                .build();
-
-        Goal updatedGoal = Goal.builder()
-                .goalId(1L)
-                .title("수정된 제목")
-                .priority(Priority.LOW)
-                .startDate(LocalDate.of(2025, 8, 1))
-                .endDate(LocalDate.of(2025, 8, 31))
-                .duration(31)
-                .isCompleted(false)
-                .build();
-
-        GoalResponseDTO expectedResponse = GoalResponseDTO.builder()
-                .goalId(1L)
-                .title("수정된 제목")
-                .priority(Priority.LOW)
-                .startDate(LocalDate.of(2025, 8, 1))
-                .endDate(LocalDate.of(2025, 8, 31))
-                .duration(31)
-                .isCompleted(false)
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-        when(goalRepositoryFacade.existsByTitleAndGoalIdNot("수정된 제목", goalId)).thenReturn(false);
-        when(goalConverter.toEntity(existingGoal, updateRequest)).thenReturn(updatedGoal);
-        when(goalRepositoryFacade.updateGoal(updatedGoal)).thenReturn(updatedGoal);
-        when(goalConverter.toGoalResponseDTO(updatedGoal)).thenReturn(expectedResponse);
-
-        // when
-        GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("수정된 제목");
-        assertThat(result.getPriority()).isEqualTo(Priority.LOW);
-        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2025, 8, 1));
-        assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2025, 8, 31));
-        assertThat(result.getDuration()).isEqualTo(31);
-    }
-
-    @Test
-    @DisplayName("목표 수정 실패 - 존재하지 않는 goalId")
-    void updateGoalById_Fail_GoalNotFound() {
-        // given
-        Long goalId = 999L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("수정된 제목")
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenThrow(new GoalException(GoalExceptionType.GOAL_NOT_FOUND));
-
-        // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("목표 수정 실패 - 유효하지 않은 제목 (빈 문자열)")
-    void updateGoalById_Fail_InvalidTitle() {
-        // given
-        Long goalId = 1L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("")
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
-    }
-
-    @Test
-    @DisplayName("목표 수정 실패 - 유효하지 않은 기간 (0)")
-    void updateGoalById_Fail_InvalidDuration() {
-        // given
-        Long goalId = 1L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .duration(0)
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
-    }
-
-    @Test
-    @DisplayName("목표 수정 실패 - 유효하지 않은 날짜 범위")
-    void updateGoalById_Fail_InvalidDateRange() {
-        // given
-        Long goalId = 1L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .startDate(LocalDate.of(2025, 12, 31))
-                .endDate(LocalDate.of(2025, 1, 1))
-                .build();
-
-        // when
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.INVALID_GOAL_DATE_RANGE);
-    }
-
-    @Test
-    @DisplayName("목표 수정 - Repository에서 예외 발생")
-    void updateGoalById_RepositoryException() {
-        // given
-        Long goalId = 1L;
-        GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
-                .title("수정된 제목")
-                .build();
-
-        Goal existingGoal = Goal.builder()
-                .goalId(1L)
-                .title("기존 제목")
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-        when(goalRepositoryFacade.updateGoal(any())).thenThrow(new RuntimeException("데이터베이스 오류"));
-
-        // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_UPDATE_FAILED);
-    }
-
-    // ========== DELETE 테스트 ==========
-
-    @Test
-    @DisplayName("목표 삭제 성공")
-    void deleteGoal_Success() {
-        // given
-        Long goalId = 1L;
-        Long userId = 1L;
-
-        when(goalRepositoryFacade.existsById(goalId)).thenReturn(true);
-        doNothing().when(goalRepositoryFacade).deleteGoal(goalId);
-
-        // when & then
-        assertThatCode(() -> goalService.deleteGoal(userId, goalId))
-                .doesNotThrowAnyException();
-
-        verify(goalRepositoryFacade).existsById(goalId);
-        verify(goalRepositoryFacade).deleteGoal(goalId);
-    }
-
-    @Test
-    @DisplayName("목표 삭제 실패 - 존재하지 않는 goalId")
-    void deleteGoal_Fail_GoalNotFound() {
-        // given
-        Long goalId = 999L;
-        Long userId = 1L;
-
-        when(goalRepositoryFacade.existsById(goalId)).thenReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
-
-        verify(goalRepositoryFacade).existsById(goalId);
-        verify(goalRepositoryFacade, never()).deleteGoal(any());
-    }
-
-    @Test
-    @DisplayName("목표 삭제 - Repository에서 예외 발생")
-    void deleteGoal_RepositoryException() {
-        // given
-        Long goalId = 1L;
-        Long userId = 1L;
-
-        when(goalRepositoryFacade.existsById(goalId)).thenReturn(true);
-        doThrow(new RuntimeException("데이터베이스 오류")).when(goalRepositoryFacade).deleteGoal(goalId);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DELETE_FAILED);
-    }
-
-    // ========== GET 테스트 ==========
-
-    @Test
-    @DisplayName("단일 목표 조회 성공")
-    void getGoalByGoalId_Success() {
-        // given
-        Long goalId = 1L;
-        Long userId = 1L;
-        Goal existingGoal = Goal.builder()
-                .goalId(1L)
-                .title("조회할 목표")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(false)
-                .build();
-
-        GoalResponseDTO expectedResponse = GoalResponseDTO.builder()
-                .goalId(1L)
-                .title("조회할 목표")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .isCompleted(false)
-                .build();
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
-        when(goalConverter.toGoalResponseDTO(existingGoal)).thenReturn(expectedResponse);
-
-        // when
-        GoalResponseDTO result = goalService.getGoalByGoalId(userId, goalId);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getTitle()).isEqualTo("조회할 목표");
-        assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
-        assertThat(result.getDuration()).isEqualTo(30);
-    }
-
-    @Test
-    @DisplayName("단일 목표 조회 실패 - null goalId")
-    void getGoalByGoalId_Fail_NullGoalId() {
-        // given
-        Long goalId = null;
-        Long userId = 1L;
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_INVALID_GOAL_ID);
-    }
-
-    @Test
-    @DisplayName("단일 목표 조회 실패 - 존재하지 않는 goalId")
-    void getGoalByGoalId_Fail_GoalNotFound() {
-        // given
-        Long goalId = 999L;
-        Long userId = 1L;
-
-        when(goalRepositoryFacade.findById(goalId)).thenReturn(null);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("단일 목표 조회 - Repository에서 예외 발생")
-    void getFindById_RepositoryException() {
-        // given
-        Long goalId = 1L;
-        Long userId = 1L;
-
-        when(goalRepositoryFacade.findById(goalId)).thenThrow(new RuntimeException("데이터베이스 오류"));
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
-    }
-
-    @Test
-    @DisplayName("사용자별 목표 목록 조회 성공 - 날짜 필터 없음")
-    void getGoalByUser_Success_NoDateFilter() {
-        // given
-        Long userId = 1L;
-        LocalDate date = null;
-
-        List<Goal> goalList = Arrays.asList(
-                Goal.builder().goalId(1L).title("목표1").build(),
-                Goal.builder().goalId(2L).title("목표2").build()
-        );
-
-        List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                GoalResponseDTO.builder().goalId(1L).title("목표1").build(),
-                GoalResponseDTO.builder().goalId(2L).title("목표2").build()
-        );
-
-        when(goalRepositoryFacade.findAllGoals()).thenReturn(goalList);
-        when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
-
-        // when
-        List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getTitle()).isEqualTo("목표1");
-        assertThat(result.get(1).getTitle()).isEqualTo("목표2");
-    }
-
-    @Test
-    @DisplayName("사용자별 목표 목록 조회 성공 - 날짜 필터 있음")
-    void getGoalByUser_Success_WithDateFilter() {
-        // given
-        Long userId = 1L;
-        LocalDate date = LocalDate.of(2025, 7, 25);
-
-
-        List<Goal> goalList = Arrays.asList(
-                Goal.builder().goalId(1L).title("현재 진행 목표").build()
-        );
-
-        List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                GoalResponseDTO.builder().goalId(1L).title("현재 진행 목표").build()
-        );
-
-        when(goalRepositoryFacade.findGoalByDate(date)).thenReturn(goalList);
-        when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
-
-        // when
-        List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTitle()).isEqualTo("현재 진행 목표");
-    }
-
-    @Test
-    @DisplayName("사용자별 목표 목록 조회 성공 - 빈 결과")
-    void getGoalByUser_Success_EmptyResult() {
-        // given
-        Long userId = 1L;
-        LocalDate date = null;
-        List<Goal> emptyGoalList = Collections.emptyList();
-        List<GoalResponseDTO> emptyResponse = Collections.emptyList();
-
-        when(goalRepositoryFacade.findAllGoals()).thenReturn(emptyGoalList);
-        when(goalConverter.toGoalResponseDTO(emptyGoalList)).thenReturn(emptyResponse);
-
-        // when
-        List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("사용자별 목표 목록 조회 - Repository에서 예외 발생")
-    void getGoalByUser_RepositoryException() {
-        // given
-        Long userId = 1L;
-        LocalDate date = null;
-
-        when(goalRepositoryFacade.findAllGoals()).thenThrow(new RuntimeException("데이터베이스 오류"));
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getGoalByUser(userId, date))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
-    }
+  // ========== UPDATE 테스트 ==========
+
+  @Test
+  @DisplayName("목표 수정 성공 - 제목만 수정")
+  void updateGoalById_Success_TitleOnly() {
+    // given
+    Long goalId = 1L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .title("수정된 제목")
+        .build();
+
+    Goal updatedGoal = Goal.builder()
+        .goalId(1L)
+        .title("수정된 제목")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(false)
+        .build();
+
+    GoalResponseDTO expectedResponse = GoalResponseDTO.builder()
+        .goalId(1L)
+        .title("수정된 제목")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(false)
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
+    when(goalRepositoryFacade.existsByTitleAndGoalIdNot("수정된 제목", goalId)).thenReturn(false);
+    when(goalConverter.toGoalResponseDTO((Goal) any())).thenReturn(expectedResponse);
+
+    // when
+    GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("수정된 제목");
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+    assertThat(result.getDuration()).isEqualTo(30);
+  }
+
+  @Test
+  @DisplayName("목표 수정 성공 - 여러 필드 수정")
+  void updateGoalById_Success_MultipleFields() {
+    // given
+    Long goalId = 1L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .title("수정된 제목")
+        .priority(Priority.LOW)
+        .startDate(LocalDate.of(2025, 8, 1))
+        .endDate(LocalDate.of(2025, 8, 31))
+        .duration(31)
+        .build();
+
+    Goal updatedGoal = Goal.builder()
+        .goalId(1L)
+        .title("수정된 제목")
+        .priority(Priority.LOW)
+        .startDate(LocalDate.of(2025, 8, 1))
+        .endDate(LocalDate.of(2025, 8, 31))
+        .duration(31)
+        .isCompleted(false)
+        .build();
+
+    GoalResponseDTO expectedResponse = GoalResponseDTO.builder()
+        .goalId(1L)
+        .title("수정된 제목")
+        .priority(Priority.LOW)
+        .startDate(LocalDate.of(2025, 8, 1))
+        .endDate(LocalDate.of(2025, 8, 31))
+        .duration(31)
+        .isCompleted(false)
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal).thenReturn(updatedGoal);
+    when(goalRepositoryFacade.existsByTitleAndGoalIdNot("수정된 제목", goalId)).thenReturn(false);
+    when(goalConverter.toGoalResponseDTO(updatedGoal)).thenReturn(expectedResponse);
+
+    // when
+    GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("수정된 제목");
+    assertThat(result.getPriority()).isEqualTo(Priority.LOW);
+    assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2025, 8, 1));
+    assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2025, 8, 31));
+    assertThat(result.getDuration()).isEqualTo(31);
+  }
+
+  @Test
+  @DisplayName("목표 수정 실패 - 존재하지 않는 goalId")
+  void updateGoalById_Fail_GoalNotFound() {
+    // given
+    Long goalId = 999L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .title("수정된 제목")
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenThrow(
+        new GoalException(GoalExceptionType.GOAL_NOT_FOUND));
+
+    // when & then
+    assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("목표 수정 실패 - 유효하지 않은 제목 (빈 문자열)")
+  void updateGoalById_Fail_InvalidTitle() {
+    // given
+    Long goalId = 1L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .title("")
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
+
+    // when & then
+    assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
+  }
+
+  @Test
+  @DisplayName("목표 수정 실패 - 유효하지 않은 기간 (0)")
+  void updateGoalById_Fail_InvalidDuration() {
+    // given
+    Long goalId = 1L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .duration(0)
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
+
+    // when & then
+    assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DURATION_INVALID);
+  }
+
+  @Test
+  @DisplayName("목표 수정 실패 - 유효하지 않은 날짜 범위")
+  void updateGoalById_Fail_InvalidDateRange() {
+    // given
+    Long goalId = 1L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .startDate(LocalDate.of(2025, 12, 31))
+        .endDate(LocalDate.of(2025, 1, 1))
+        .build();
+
+    // when
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
+
+    // when & then
+    assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType",
+            GoalExceptionType.INVALID_GOAL_DATE_RANGE);
+  }
+
+  @Test
+  @DisplayName("목표 수정 - Repository에서 예외 발생")
+  void updateGoalById_RepositoryException() {
+    // given
+    Long goalId = 1L;
+    GoalUpdateRequestDTO updateRequest = GoalUpdateRequestDTO.builder()
+        .title("수정된 제목")
+        .build();
+
+    Goal existingGoal = Goal.builder()
+        .goalId(1L)
+        .title("기존 제목")
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
+    when(goalRepositoryFacade.existsByTitleAndGoalIdNot(any(), any())).thenThrow(
+        new RuntimeException("데이터베이스 오류"));
+
+    // when & then
+    assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_UPDATE_FAILED);
+  }
+
+  // ========== DELETE 테스트 ==========
+
+  @Test
+  @DisplayName("목표 삭제 성공")
+  void deleteGoal_Success() {
+    // given
+    Long goalId = 1L;
+    Long userId = 1L;
+
+    when(goalRepositoryFacade.existsById(goalId)).thenReturn(true);
+    doNothing().when(goalRepositoryFacade).deleteGoal(goalId);
+
+    // when & then
+    assertThatCode(() -> goalService.deleteGoal(userId, goalId))
+        .doesNotThrowAnyException();
+
+    verify(goalRepositoryFacade).existsById(goalId);
+    verify(goalRepositoryFacade).deleteGoal(goalId);
+  }
+
+  @Test
+  @DisplayName("목표 삭제 실패 - 존재하지 않는 goalId")
+  void deleteGoal_Fail_GoalNotFound() {
+    // given
+    Long goalId = 999L;
+    Long userId = 1L;
+
+    when(goalRepositoryFacade.existsById(goalId)).thenReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
+
+    verify(goalRepositoryFacade).existsById(goalId);
+    verify(goalRepositoryFacade, never()).deleteGoal(any());
+  }
+
+  @Test
+  @DisplayName("목표 삭제 - Repository에서 예외 발생")
+  void deleteGoal_RepositoryException() {
+    // given
+    Long goalId = 1L;
+    Long userId = 1L;
+
+    when(goalRepositoryFacade.existsById(goalId)).thenReturn(true);
+    doThrow(new RuntimeException("데이터베이스 오류")).when(goalRepositoryFacade).deleteGoal(goalId);
+
+    // when & then
+    assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DELETE_FAILED);
+  }
+
+  // ========== GET 테스트 ==========
+
+  @Test
+  @DisplayName("단일 목표 조회 성공")
+  void getGoalByGoalId_Success() {
+    // given
+    Long goalId = 1L;
+    Long userId = 1L;
+    Goal existingGoal = Goal.builder()
+        .goalId(1L)
+        .title("조회할 목표")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(false)
+        .build();
+
+    GoalResponseDTO expectedResponse = GoalResponseDTO.builder()
+        .goalId(1L)
+        .title("조회할 목표")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .isCompleted(false)
+        .build();
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(existingGoal);
+    when(goalConverter.toGoalResponseDTO(existingGoal)).thenReturn(expectedResponse);
+
+    // when
+    GoalResponseDTO result = goalService.getGoalByGoalId(userId, goalId);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getGoalId()).isEqualTo(1L);
+    assertThat(result.getTitle()).isEqualTo("조회할 목표");
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+    assertThat(result.getDuration()).isEqualTo(30);
+  }
+
+  @Test
+  @DisplayName("단일 목표 조회 실패 - null goalId")
+  void getGoalByGoalId_Fail_NullGoalId() {
+    // given
+    Long goalId = null;
+    Long userId = 1L;
+
+    // when & then
+    assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_INVALID_GOAL_ID);
+  }
+
+  @Test
+  @DisplayName("단일 목표 조회 실패 - 존재하지 않는 goalId")
+  void getGoalByGoalId_Fail_GoalNotFound() {
+    // given
+    Long goalId = 999L;
+    Long userId = 1L;
+
+    when(goalRepositoryFacade.findById(goalId)).thenReturn(null);
+
+    // when & then
+    assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("단일 목표 조회 - Repository에서 예외 발생")
+  void getFindById_RepositoryException() {
+    // given
+    Long goalId = 1L;
+    Long userId = 1L;
+
+    when(goalRepositoryFacade.findById(goalId)).thenThrow(new RuntimeException("데이터베이스 오류"));
+
+    // when & then
+    assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
+  }
+
+  @Test
+  @DisplayName("사용자별 목표 목록 조회 성공 - 날짜 필터 없음")
+  void getGoalByUser_Success_NoDateFilter() {
+    // given
+    Long userId = 1L;
+    LocalDate date = null;
+
+    List<Goal> goalList = Arrays.asList(
+        Goal.builder().goalId(1L).title("목표1").build(),
+        Goal.builder().goalId(2L).title("목표2").build()
+    );
+
+    List<GoalResponseDTO> expectedResponse = Arrays.asList(
+        GoalResponseDTO.builder().goalId(1L).title("목표1").build(),
+        GoalResponseDTO.builder().goalId(2L).title("목표2").build()
+    );
+
+    when(goalRepositoryFacade.findAllGoals()).thenReturn(goalList);
+    when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
+
+    // when
+    List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getTitle()).isEqualTo("목표1");
+    assertThat(result.get(1).getTitle()).isEqualTo("목표2");
+  }
+
+  @Test
+  @DisplayName("사용자별 목표 목록 조회 성공 - 날짜 필터 있음")
+  void getGoalByUser_Success_WithDateFilter() {
+    // given
+    Long userId = 1L;
+    LocalDate date = LocalDate.of(2025, 7, 25);
+
+    List<Goal> goalList = Arrays.asList(
+        Goal.builder().goalId(1L).title("현재 진행 목표").build()
+    );
+
+    List<GoalResponseDTO> expectedResponse = Arrays.asList(
+        GoalResponseDTO.builder().goalId(1L).title("현재 진행 목표").build()
+    );
+
+    when(goalRepositoryFacade.findGoalByDate(date)).thenReturn(goalList);
+    when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
+
+    // when
+    List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getTitle()).isEqualTo("현재 진행 목표");
+  }
+
+  @Test
+  @DisplayName("사용자별 목표 목록 조회 성공 - 빈 결과")
+  void getGoalByUser_Success_EmptyResult() {
+    // given
+    Long userId = 1L;
+    LocalDate date = null;
+    List<Goal> emptyGoalList = Collections.emptyList();
+    List<GoalResponseDTO> emptyResponse = Collections.emptyList();
+
+    when(goalRepositoryFacade.findAllGoals()).thenReturn(emptyGoalList);
+    when(goalConverter.toGoalResponseDTO(emptyGoalList)).thenReturn(emptyResponse);
+
+    // when
+    List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("사용자별 목표 목록 조회 - Repository에서 예외 발생")
+  void getGoalByUser_RepositoryException() {
+    // given
+    Long userId = 1L;
+    LocalDate date = null;
+
+    when(goalRepositoryFacade.findAllGoals()).thenThrow(new RuntimeException("데이터베이스 오류"));
+
+    // when & then
+    assertThatThrownBy(() -> goalService.getGoalByUser(userId, date))
+        .isInstanceOf(GoalException.class)
+        .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
+  }
 
   @Test
   @DisplayName("소목표 생성 성공 테스트")

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceTest.java
@@ -76,8 +76,6 @@ class SubGoalServiceTest {
 
     // given
     when(subGoalRepositoryFacade.findSubGoalBySubGoalId(1L)).thenReturn(validSubGoal);
-    when(subGoalConverter.toSubGoalEntity(validSubGoal, validSubGoalUpdateRequestDTO)).thenReturn(
-        updatedSubGoal);
 
     // when
     SubGoalUpdateResponseDTO responseDTO = subGoalService.updateSubGoal(1L,

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
@@ -1,18 +1,29 @@
 package com.hotpack.krocs.domain.templates.service;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.hotpack.krocs.domain.templates.converter.TemplateConverter;
 import com.hotpack.krocs.domain.templates.domain.Template;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateCreateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateUpdateRequestDTO;
-import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
+import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateResponseDTO;
 import com.hotpack.krocs.domain.templates.exception.TemplateException;
 import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
 import com.hotpack.krocs.domain.templates.validator.TemplateValidator;
 import com.hotpack.krocs.global.common.entity.Priority;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,326 +33,314 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class TemplateServiceTest {
 
-    @Mock
-    private TemplateRepositoryFacade templateRepositoryFacade;
+  @Mock
+  private TemplateRepositoryFacade templateRepositoryFacade;
 
-    @Spy
-    private TemplateValidator templateValidator = new TemplateValidator(); // 수동 생성
+  @Spy
+  private TemplateValidator templateValidator = new TemplateValidator(); // 수동 생성
 
-    @Mock
-    private TemplateConverter templateConverter;
+  @Mock
+  private TemplateConverter templateConverter;
 
-    @InjectMocks
-    private TemplateServiceImpl templateService;
+  @InjectMocks
+  private TemplateServiceImpl templateService;
 
-    private TemplateCreateRequestDTO validCreateRequestDTO;
-    private TemplateUpdateRequestDTO validUpdateRequestDTO;
-    private Template validTemplate;
-    private TemplateCreateResponseDTO validCreateResponseDTO;
-    private TemplateResponseDTO validResponseDTO;
-    private SubTemplateResponseDTO subTemplateResponseDTO;
+  private TemplateCreateRequestDTO validCreateRequestDTO;
+  private TemplateUpdateRequestDTO validUpdateRequestDTO;
+  private Template validTemplate;
+  private TemplateCreateResponseDTO validCreateResponseDTO;
+  private TemplateResponseDTO validResponseDTO;
+  private SubTemplateResponseDTO subTemplateResponseDTO;
 
-    @BeforeEach
-    void setUp() {
-        validCreateRequestDTO = TemplateCreateRequestDTO.builder()
-                .title("공부 루틴")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .build();
+  @BeforeEach
+  void setUp() {
+    validCreateRequestDTO = TemplateCreateRequestDTO.builder()
+        .title("공부 루틴")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .build();
 
-        validUpdateRequestDTO = TemplateUpdateRequestDTO.builder()
-                .title("수정된 루틴")
-                .priority(Priority.LOW)
-                .duration(60)
-                .build();
+    validUpdateRequestDTO = TemplateUpdateRequestDTO.builder()
+        .title("수정된 루틴")
+        .priority(Priority.LOW)
+        .duration(60)
+        .build();
 
-        validTemplate = Template.builder()
-                .templateId(1L)
-                .title("공부 루틴")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .subTemplates(new ArrayList<>())
-                .build();
+    validTemplate = Template.builder()
+        .templateId(1L)
+        .title("공부 루틴")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .subTemplates(new ArrayList<>())
+        .build();
 
-        validCreateResponseDTO = TemplateCreateResponseDTO.builder()
-                .templateId(1L)
-                .title("공부 루틴")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .build();
+    validCreateResponseDTO = TemplateCreateResponseDTO.builder()
+        .templateId(1L)
+        .title("공부 루틴")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .build();
 
-        validResponseDTO = TemplateResponseDTO.builder()
-                .templateId(1L)
-                .title("공부 루틴")
-                .priority(Priority.HIGH)
-                .duration(30)
-                .subTemplates(Collections.emptyList())
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-    }
+    validResponseDTO = TemplateResponseDTO.builder()
+        .templateId(1L)
+        .title("공부 루틴")
+        .priority(Priority.HIGH)
+        .duration(30)
+        .subTemplates(Collections.emptyList())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
 
-    // ======= CREATE =======
-
-
-    @Test
-    @DisplayName("템플릿 생성 성공 테스트")
-    void createTemplate_Success() {
-        // given
-        when(templateConverter.toEntity(validCreateRequestDTO)).thenReturn(validTemplate);
-        when(templateRepositoryFacade.save(validTemplate)).thenReturn(validTemplate);
-        when(templateConverter.toCreateResponseDTO(validTemplate)).thenReturn(validCreateResponseDTO);
-
-        // when
-        TemplateCreateResponseDTO result = templateService.createTemplate(validCreateRequestDTO, 2L);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTitle()).isEqualTo("공부 루틴");
-        assertThat(result.getDuration()).isEqualTo(30);
-        assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
-    }
-
-    @Test
-    @DisplayName("DTO 기본값 테스트 - priority는 명시하지 않으면 MEDIUM으로 설정된다")
-    void createTemplateRequestDTO_DefaultPriority_ShouldBeMedium() {
-        // given
-        TemplateCreateRequestDTO result = TemplateCreateRequestDTO.builder()
-                .title("공부 루틴")
-                .duration(30)
-                .build();
-
-        // then
-        assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM);
-    }
+  // ======= CREATE =======
 
 
-    @Test
-    @DisplayName("템플릿 생성 실패 - title이 공백인 경우")
-    void createTemplate_Fail_BlankTitle() {
-        // given
-        TemplateCreateRequestDTO request = TemplateCreateRequestDTO.builder()
-                .title("")            // 빈 제목
-                .priority(Priority.HIGH)
-                .duration(10)
-                .build();
+  @Test
+  @DisplayName("템플릿 생성 성공 테스트")
+  void createTemplate_Success() {
+    // given
+    when(templateConverter.toEntity(validCreateRequestDTO)).thenReturn(validTemplate);
+    when(templateRepositoryFacade.save(validTemplate)).thenReturn(validTemplate);
+    when(templateConverter.toCreateResponseDTO(validTemplate)).thenReturn(validCreateResponseDTO);
 
-        // when & then
-        TemplateException ex = assertThrows(
-                TemplateException.class,
-                () -> templateService.createTemplate(request, 1L)
-        );
+    // when
+    TemplateCreateResponseDTO result = templateService.createTemplate(validCreateRequestDTO, 2L);
 
-        assertThat(ex.getTemplateExceptionType())
-                .isEqualTo(TemplateExceptionType.TEMPLATE_TITLE_EMPTY);
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("공부 루틴");
+    assertThat(result.getDuration()).isEqualTo(30);
+    assertThat(result.getPriority()).isEqualTo(Priority.HIGH);
+  }
 
-        // 그리고 validateTitle 메서드가 실제로 호출됐는지 확인해 줄 수도 있어요
-        verify(templateValidator).validateTitle("");
-    }
+  @Test
+  @DisplayName("DTO 기본값 테스트 - priority는 명시하지 않으면 MEDIUM으로 설정된다")
+  void createTemplateRequestDTO_DefaultPriority_ShouldBeMedium() {
+    // given
+    TemplateCreateRequestDTO result = TemplateCreateRequestDTO.builder()
+        .title("공부 루틴")
+        .duration(30)
+        .build();
 
-    @Test
-    @DisplayName("템플릿 생성 실패 - duration이 음수인 경우")
-    void createTemplate_Fail_NegativeDuration() {
-        // given
-        TemplateCreateRequestDTO request = TemplateCreateRequestDTO.builder()
-                .title("공부")
-                .priority(Priority.HIGH)
-                .duration(-10)
-                .build();
-
-        // when & then
-        TemplateException exception = assertThrows(TemplateException.class,
-                () -> templateService.createTemplate(request, 1L));
-
-        assertThat(exception.getTemplateExceptionType())
-                .isEqualTo(TemplateExceptionType.TEMPLATE_DURATION_INVALID);
-    }
-
-    // ======= READ =======
-    @Test
-    @DisplayName("템플릿 전체 조회 성공 - 제목 없이 조회")
-    void getTemplates_Success_WithoutTitle() {
-        // given
-
-        when(templateRepositoryFacade.findAll())
-                .thenReturn(List.of(validTemplate));
-
-        when(templateConverter.toTemplateResponseDTO(validTemplate))
-                .thenReturn(validResponseDTO);
-
-        // when
-        List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, null);
-
-        // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTitle()).isEqualTo("공부 루틴");
-    }
-
-    @Test
-    @DisplayName("템플릿 검색 조회 성공 - 제목 키워드 포함")
-    void getTemplates_Success_WithKeyword() {
-        // when
-        when(templateRepositoryFacade.findByTitle("공부"))
-                .thenReturn(List.of(validTemplate));
-
-        when(templateConverter.toTemplateResponseDTO(validTemplate))
-                .thenReturn(validResponseDTO);
-
-        // then
-        List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, "공부");
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTitle()).contains("공부");
-    }
-
-    @Test
-    @DisplayName("템플릿 검색 조회 - 결과가 없는 경우")
-    void getTemplates_EmptyResult() {
-
-        // then
-        List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, "운동");
-        assertThat(result).isEmpty();
-    }
+    // then
+    assertThat(result.getPriority()).isEqualTo(Priority.MEDIUM);
+  }
 
 
-    // ======= UPDATE =======
+  @Test
+  @DisplayName("템플릿 생성 실패 - title이 공백인 경우")
+  void createTemplate_Fail_BlankTitle() {
+    // given
+    TemplateCreateRequestDTO request = TemplateCreateRequestDTO.builder()
+        .title("")            // 빈 제목
+        .priority(Priority.HIGH)
+        .duration(10)
+        .build();
 
-    @Test
-    @DisplayName("템플릿 수정 성공")
-    void updateTemplate_Success() {
-        // given
-        Template existed = validTemplate;
-        TemplateUpdateRequestDTO dto = validUpdateRequestDTO;
+    // when & then
+    TemplateException ex = assertThrows(
+        TemplateException.class,
+        () -> templateService.createTemplate(request, 1L)
+    );
 
-        when(templateRepositoryFacade.findByTemplateId(1L))
-                .thenReturn(existed);
+    assertThat(ex.getTemplateExceptionType())
+        .isEqualTo(TemplateExceptionType.TEMPLATE_TITLE_EMPTY);
 
-        Template updatedEntity = Template.builder()
-                .templateId(1L)
-                .title(dto.getTitle())
-                .priority(dto.getPriority())
-                .duration(dto.getDuration())
-                .subTemplates(new ArrayList<>())
-                .build();
+    // 그리고 validateTitle 메서드가 실제로 호출됐는지 확인해 줄 수도 있어요
+    verify(templateValidator).validateTitle("");
+  }
 
-        when(templateConverter.toEntityUpdate(existed, dto))
-                .thenReturn(updatedEntity);
+  @Test
+  @DisplayName("템플릿 생성 실패 - duration이 음수인 경우")
+  void createTemplate_Fail_NegativeDuration() {
+    // given
+    TemplateCreateRequestDTO request = TemplateCreateRequestDTO.builder()
+        .title("공부")
+        .priority(Priority.HIGH)
+        .duration(-10)
+        .build();
 
-        when(templateRepositoryFacade.update(updatedEntity))
-                .thenReturn(updatedEntity);
+    // when & then
+    TemplateException exception = assertThrows(TemplateException.class,
+        () -> templateService.createTemplate(request, 1L));
 
-        TemplateResponseDTO validResponseDTO = TemplateResponseDTO.builder()
-                .templateId(1L)
-                .title("수정된 루틴")
-                .priority(Priority.LOW)
-                .duration(60)
-                .subTemplates(Collections.emptyList())
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
+    assertThat(exception.getTemplateExceptionType())
+        .isEqualTo(TemplateExceptionType.TEMPLATE_DURATION_INVALID);
+  }
 
-        when(templateConverter.toTemplateResponseDTO(updatedEntity))
-                .thenReturn(validResponseDTO);
+  // ======= READ =======
+  @Test
+  @DisplayName("템플릿 전체 조회 성공 - 제목 없이 조회")
+  void getTemplates_Success_WithoutTitle() {
+    // given
 
-        // when
-        TemplateResponseDTO response = templateService.updateTemplate(1L, 1L, dto);
+    when(templateRepositoryFacade.findAll())
+        .thenReturn(List.of(validTemplate));
 
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getTitle()).isEqualTo(dto.getTitle());
-        assertThat(response.getPriority()).isEqualTo(dto.getPriority());
-        assertThat(response.getDuration()).isEqualTo(dto.getDuration());
-    }
+    when(templateConverter.toTemplateResponseDTO(validTemplate))
+        .thenReturn(validResponseDTO);
+
+    // when
+    List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, null);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getTitle()).isEqualTo("공부 루틴");
+  }
+
+  @Test
+  @DisplayName("템플릿 검색 조회 성공 - 제목 키워드 포함")
+  void getTemplates_Success_WithKeyword() {
+    // when
+    when(templateRepositoryFacade.findByTitle("공부"))
+        .thenReturn(List.of(validTemplate));
+
+    when(templateConverter.toTemplateResponseDTO(validTemplate))
+        .thenReturn(validResponseDTO);
+
+    // then
+    List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, "공부");
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getTitle()).contains("공부");
+  }
+
+  @Test
+  @DisplayName("템플릿 검색 조회 - 결과가 없는 경우")
+  void getTemplates_EmptyResult() {
+
+    // then
+    List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, "운동");
+    assertThat(result).isEmpty();
+  }
+
+  // ======= UPDATE =======
+
+  @Test
+  @DisplayName("템플릿 수정 성공")
+  void updateTemplate_Success() {
+    // given
+    Template existed = validTemplate;
+    TemplateUpdateRequestDTO dto = validUpdateRequestDTO;
+
+    Template updatedEntity = Template.builder()
+        .templateId(1L)
+        .title(dto.getTitle())
+        .priority(dto.getPriority())
+        .duration(dto.getDuration())
+        .subTemplates(new ArrayList<>())
+        .build();
+
+    TemplateResponseDTO validResponseDTO = TemplateResponseDTO.builder()
+        .templateId(1L)
+        .title("수정된 루틴")
+        .priority(Priority.LOW)
+        .duration(60)
+        .subTemplates(Collections.emptyList())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    when(templateConverter.toTemplateResponseDTO(updatedEntity))
+        .thenReturn(validResponseDTO);
+
+    when(templateRepositoryFacade.findByTemplateId(1L))
+        .thenReturn(existed).thenReturn(updatedEntity);
+
+    // when
+    TemplateResponseDTO response = templateService.updateTemplate(1L, 1L, dto);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo(dto.getTitle());
+    assertThat(response.getPriority()).isEqualTo(dto.getPriority());
+    assertThat(response.getDuration()).isEqualTo(dto.getDuration());
+  }
 
 
-    @Test
-    @DisplayName("템플릿 수정 실패 - title이 최대값(200자) 초과")
-    void updateTemplate_Fail_TitleExceedsLimit() {
-        // given
-        Template existingTemplate = Template.builder()
-                .templateId(1L)
-                .title("기존 루틴")
-                .priority(Priority.MEDIUM)
-                .duration(30)
-                .subTemplates(List.of())
-                .build();
+  @Test
+  @DisplayName("템플릿 수정 실패 - title이 최대값(200자) 초과")
+  void updateTemplate_Fail_TitleExceedsLimit() {
+    // given
+    Template existingTemplate = Template.builder()
+        .templateId(1L)
+        .title("기존 루틴")
+        .priority(Priority.MEDIUM)
+        .duration(30)
+        .subTemplates(List.of())
+        .build();
 
-        String overLengthTitle = "a".repeat(201); // 201자짜리 title
-        TemplateUpdateRequestDTO requestDTO = TemplateUpdateRequestDTO.builder()
-                .title(overLengthTitle)
-                .build();
+    String overLengthTitle = "a".repeat(201); // 201자짜리 title
+    TemplateUpdateRequestDTO requestDTO = TemplateUpdateRequestDTO.builder()
+        .title(overLengthTitle)
+        .build();
 
-        // when
-        TemplateException exception = catchThrowableOfType(
-                () -> templateService.updateTemplate(1L, 1L, requestDTO),
-                TemplateException.class
-        );
+    // when
+    TemplateException exception = catchThrowableOfType(
+        () -> templateService.updateTemplate(1L, 1L, requestDTO),
+        TemplateException.class
+    );
 
-        // then
-        assertThat(exception).isNotNull();
-        assertThat(exception.getTemplateExceptionType()).isEqualTo(TemplateExceptionType.TEMPLATE_TITLE_TOO_LONG);
-    }
+    // then
+    assertThat(exception).isNotNull();
+    assertThat(exception.getTemplateExceptionType()).isEqualTo(
+        TemplateExceptionType.TEMPLATE_TITLE_TOO_LONG);
+  }
 
-    @Test
-    @DisplayName("템플릿 수정 실패 - 존재하지 않는 템플릿")
-    void updateTemplate_Fail_TemplateNotFound() {
-        // when
-        when(templateRepositoryFacade.findByTemplateId(1L))
-                .thenThrow(new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND));
+  @Test
+  @DisplayName("템플릿 수정 실패 - 존재하지 않는 템플릿")
+  void updateTemplate_Fail_TemplateNotFound() {
+    // when
+    when(templateRepositoryFacade.findByTemplateId(1L))
+        .thenThrow(new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND));
+
+    TemplateException exception = catchThrowableOfType(
+        () -> templateService.updateTemplate(1L, 1L, validUpdateRequestDTO),
+        TemplateException.class
+    );
+
+    // then
+    assertThat(exception).isNotNull();
+    assertThat(exception.getTemplateExceptionType()).isEqualTo(
+        TemplateExceptionType.TEMPLATE_NOT_FOUND);
+  }
 
 
-        TemplateException exception = catchThrowableOfType(
-                () -> templateService.updateTemplate(1L, 1L, validUpdateRequestDTO),
-                TemplateException.class
-        );
+  // D - 템플릿 삭제 성공
+  @Test
+  @DisplayName("템플릿 삭제 성공")
+  void deleteTemplate_Success() {
+    // when
+    when(templateRepositoryFacade.findByTemplateId(1L))
+        .thenReturn(validTemplate);
 
-        // then
-        assertThat(exception).isNotNull();
-        assertThat(exception.getTemplateExceptionType()).isEqualTo(TemplateExceptionType.TEMPLATE_NOT_FOUND);
-    }
+    // then
+    assertThatCode(() -> templateService.deleteTemplate(1L, 1L))
+        .doesNotThrowAnyException();
 
+    verify(templateRepositoryFacade).delete(validTemplate);
+  }
 
-    // D - 템플릿 삭제 성공
-    @Test
-    @DisplayName("템플릿 삭제 성공")
-    void deleteTemplate_Success() {
-        // when
-        when(templateRepositoryFacade.findByTemplateId(1L))
-                .thenReturn(validTemplate);
+  @Test
+  @DisplayName("템플릿 삭제 실패 - 존재하지 않는 템플릿")
+  void deleteTemplate_Fail_TemplateNotFound() {
+    // when
 
-        // then
-        assertThatCode(() -> templateService.deleteTemplate(1L, 1L))
-                .doesNotThrowAnyException();
+    when(templateRepositoryFacade.findByTemplateId(1L))
+        .thenThrow(new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND));
 
-        verify(templateRepositoryFacade).delete(validTemplate);
-    }
+    TemplateException exception = catchThrowableOfType(
+        () -> templateService.deleteTemplate(1L, 1L),
+        TemplateException.class
+    );
 
-    @Test
-    @DisplayName("템플릿 삭제 실패 - 존재하지 않는 템플릿")
-    void deleteTemplate_Fail_TemplateNotFound() {
-        // when
-
-        when(templateRepositoryFacade.findByTemplateId(1L))
-                .thenThrow(new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND));
-
-        TemplateException exception = catchThrowableOfType(
-                () -> templateService.deleteTemplate(1L, 1L),
-                TemplateException.class
-        );
-
-        // then
-        assertThat(exception).isNotNull();
-        assertThat(exception.getTemplateExceptionType()).isEqualTo(TemplateExceptionType.TEMPLATE_NOT_FOUND);
-    }
+    // then
+    assertThat(exception).isNotNull();
+    assertThat(exception.getTemplateExceptionType()).isEqualTo(
+        TemplateExceptionType.TEMPLATE_NOT_FOUND);
+  }
 
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #60 

## 📝 수정 요약
<!-- 먼저 버그에 대한 간단한 설명을 적어주세요 -->

- 🚨 문제점
1. SubGoalService.updateSubGoal() 메서드에서 수정된 값이 저장되지 않습니다.
2. 모든 수정 비지니스 로직의 반환값에 `created_at`, `updated_at` 이 `null` 입니다.

- 🔍 원인 분석

> 우선 기존 update 로직은 아래의 순서이다.
> 1. 수정할 엔티티를 id로 조회하여 가져온다. -> entity1
> 2. `updateRequestDTO`의 변경값(not null)과 entity1의 값을 갖는 새로운 엔티티를 이용해 생성한다. -> entity2
> 3. 레포지토리의 save를 이용하여 entity2를 저장한다.(entity1의 id가 들어갔으므로. update가 가능하다.)
> 
> 위의 과정에서 원인을 추정해보겠다.
> 이때 새로운 entity를 임의로 생성하면 created_at과 updated_at이 null로 지정된다.
> 그리고 저장을 하게 되면 updated_at은 갱신 되지만, created_at은 `@Column(updatable = false)` 이므로 갱신되지 않고 null이 들어간다.
> 
> 하지만 위의 설명에서 우려스러운 점은 트렌젝션이 완료된 후에 DB의 created_at의 값이 null이 아니라는 점이다. 따라서 더 정확히 원인을 분석할 필요가 있다.

- 💡 해결 방법
> 해결 방법은 아래의 순서로 update 로직을 변경한 것이다.
> 1. 엔티티 class에 updateFrom() 메서드를 정의한다.(updateFrom() 메서드는 updateRequestDTO를 파라미터로 받아 필드의 값을 수정하는 메서드이다.)
> 2. 서비스 계층에서 id를 이용해 update 할 엔티티를 불러온다.
> 3. updateFrom() 메서드를 이용해 값을 수정한다.
> 4. findById() 메서드로 update 된 엔티티를 다시 불러온다.
> 5. responseDTO로 변환해 반환한다.
>
> 4번을 적용한 이유는 updateFrom()을 수행한 뒤 바로 responseDTO로 반환하면 updated_at이 곧바로 최신화 되지 않기 때문에(Lazy하게 설정되어있음) 불가피하게 id를 이용하여 수정한 엔티티를 다시 한 번 조회하였다.

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)
@soheeGit 
@gawoooon 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
20분