### PR TITLE
[feat] 서브템플릿 생성 API 및 서비스 구현

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
@@ -1,12 +1,17 @@
 package com.hotpack.krocs.domain.templates.controller;
 
 
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateCreateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateUpdateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateResponseDTO;
+import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
+import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
 import com.hotpack.krocs.domain.templates.exception.TemplateException;
 import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
+import com.hotpack.krocs.domain.templates.service.SubTemplateService;
 import com.hotpack.krocs.domain.templates.service.TemplateService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,8 +37,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class TemplateController {
 
   private final TemplateService templateService;
+  private final SubTemplateService subTemplateService;
 
-  @Operation(summary = "템플릿 생성", description = "title, priority, duration을 설정해 템플릿을 생성합니다.")
+  @Operation(summary = "템플릿 생성", description = "title, priority을 설정해 템플릿을 생성합니다.")
   @PostMapping
   public ApiResponse<TemplateCreateResponseDTO> createTemplate(
       @Valid @RequestBody TemplateCreateRequestDTO requestDTO,
@@ -105,4 +111,25 @@ public class TemplateController {
       throw new TemplateException(TemplateExceptionType.TEMPLATE_DELETE_FAILED);
     }
   }
+
+  //============== SubTemplate ==============
+
+  @Operation(summary = "서브 템플릿 생성", description = "템플릿에 종속된 서브 템플릿을 생성합니다.")
+  @PostMapping("/{templateId}/subTemplates")
+  public ApiResponse<SubTemplateCreateResponseDTO> saveSubTemplates(
+      @Valid @RequestBody SubTemplateCreateRequestDTO requestDTO,
+      @PathVariable(value = "templateId") Long templateId,
+      @RequestParam(value = "userId") Long userId
+  ) {
+    try {
+      SubTemplateCreateResponseDTO responseDTO = subTemplateService.createSubTemplates(templateId,
+          requestDTO, userId);
+      return ApiResponse.success(responseDTO);
+    } catch (SubTemplateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
+    }
+  }
+
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverter.java
@@ -1,0 +1,53 @@
+package com.hotpack.krocs.domain.templates.converter;
+
+import com.hotpack.krocs.domain.templates.domain.SubTemplate;
+import com.hotpack.krocs.domain.templates.domain.Template;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SubTemplateConverter {
+
+  public List<SubTemplate> toSubTemplateEntityList(Template template,
+      SubTemplateCreateRequestDTO requestDTO) {
+    List<SubTemplate> subTemplates = new ArrayList<>();
+    for (SubTemplateRequestDTO subTemplateRequestDTO : requestDTO.getSubTemplates()) {
+      subTemplates.add(toSubTemplateEntity(template, subTemplateRequestDTO));
+    }
+    return subTemplates;
+  }
+
+  public SubTemplate toSubTemplateEntity(Template template, SubTemplateRequestDTO requestDTO) {
+    return SubTemplate.builder()
+        .title(requestDTO.getTitle())
+        .template(template)
+        .build();
+  }
+
+  public SubTemplateCreateResponseDTO toSubTemplateCreateResponseDTO(
+      List<SubTemplate> subTemplates) {
+    List<SubTemplateResponseDTO> subTemplateResponseDTOs = new ArrayList<>();
+    for (SubTemplate subTemplate : subTemplates) {
+      subTemplateResponseDTOs.add(toSubTemplateResponseDTO(subTemplate));
+    }
+
+    return SubTemplateCreateResponseDTO.builder()
+        .subTemplates(subTemplateResponseDTOs)
+        .build();
+  }
+
+  public SubTemplateResponseDTO toSubTemplateResponseDTO(SubTemplate subTemplate) {
+    return SubTemplateResponseDTO.builder()
+        .subTemplateId(subTemplate.getSubTemplateId())
+        .templateId(subTemplate.getSubTemplateId())
+        .title(subTemplate.getTitle())
+        .createdAt(subTemplate.getCreatedAt())
+        .updatedAt(subTemplate.getUpdatedAt())
+        .build();
+  }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverter.java
@@ -13,41 +13,41 @@ import org.springframework.stereotype.Component;
 @Component
 public class SubTemplateConverter {
 
-  public List<SubTemplate> toSubTemplateEntityList(Template template,
-      SubTemplateCreateRequestDTO requestDTO) {
-    List<SubTemplate> subTemplates = new ArrayList<>();
-    for (SubTemplateRequestDTO subTemplateRequestDTO : requestDTO.getSubTemplates()) {
-      subTemplates.add(toSubTemplateEntity(template, subTemplateRequestDTO));
-    }
-    return subTemplates;
-  }
-
-  public SubTemplate toSubTemplateEntity(Template template, SubTemplateRequestDTO requestDTO) {
-    return SubTemplate.builder()
-        .title(requestDTO.getTitle())
-        .template(template)
-        .build();
-  }
-
-  public SubTemplateCreateResponseDTO toSubTemplateCreateResponseDTO(
-      List<SubTemplate> subTemplates) {
-    List<SubTemplateResponseDTO> subTemplateResponseDTOs = new ArrayList<>();
-    for (SubTemplate subTemplate : subTemplates) {
-      subTemplateResponseDTOs.add(toSubTemplateResponseDTO(subTemplate));
+    public List<SubTemplate> toSubTemplateEntityList(Template template,
+        SubTemplateCreateRequestDTO requestDTO) {
+        List<SubTemplate> subTemplates = new ArrayList<>();
+        for (SubTemplateRequestDTO subTemplateRequestDTO : requestDTO.getSubTemplates()) {
+            subTemplates.add(toSubTemplateEntity(template, subTemplateRequestDTO));
+        }
+        return subTemplates;
     }
 
-    return SubTemplateCreateResponseDTO.builder()
-        .subTemplates(subTemplateResponseDTOs)
-        .build();
-  }
+    public SubTemplate toSubTemplateEntity(Template template, SubTemplateRequestDTO requestDTO) {
+        return SubTemplate.builder()
+            .title(requestDTO.getTitle())
+            .template(template)
+            .build();
+    }
 
-  public SubTemplateResponseDTO toSubTemplateResponseDTO(SubTemplate subTemplate) {
-    return SubTemplateResponseDTO.builder()
-        .subTemplateId(subTemplate.getSubTemplateId())
-        .templateId(subTemplate.getSubTemplateId())
-        .title(subTemplate.getTitle())
-        .createdAt(subTemplate.getCreatedAt())
-        .updatedAt(subTemplate.getUpdatedAt())
-        .build();
-  }
+    public SubTemplateCreateResponseDTO toSubTemplateCreateResponseDTO(
+        List<SubTemplate> subTemplates) {
+        List<SubTemplateResponseDTO> subTemplateResponseDTOs = new ArrayList<>();
+        for (SubTemplate subTemplate : subTemplates) {
+            subTemplateResponseDTOs.add(toSubTemplateResponseDTO(subTemplate));
+        }
+
+        return SubTemplateCreateResponseDTO.builder()
+            .subTemplates(subTemplateResponseDTOs)
+            .build();
+    }
+
+    public SubTemplateResponseDTO toSubTemplateResponseDTO(SubTemplate subTemplate) {
+        return SubTemplateResponseDTO.builder()
+            .subTemplateId(subTemplate.getSubTemplateId())
+            .templateId(subTemplate.getTemplate().getTemplateId())
+            .title(subTemplate.getTitle())
+            .createdAt(subTemplate.getCreatedAt())
+            .updatedAt(subTemplate.getUpdatedAt())
+            .build();
+    }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverter.java
@@ -13,27 +13,27 @@ import org.springframework.stereotype.Component;
 @Component
 public class SubTemplateConverter {
 
-    public List<SubTemplate> toSubTemplateEntityList(Template template,
+    public List<SubTemplate> toEntityList(Template template,
         SubTemplateCreateRequestDTO requestDTO) {
         List<SubTemplate> subTemplates = new ArrayList<>();
         for (SubTemplateRequestDTO subTemplateRequestDTO : requestDTO.getSubTemplates()) {
-            subTemplates.add(toSubTemplateEntity(template, subTemplateRequestDTO));
+            subTemplates.add(toEntity(template, subTemplateRequestDTO));
         }
         return subTemplates;
     }
 
-    public SubTemplate toSubTemplateEntity(Template template, SubTemplateRequestDTO requestDTO) {
+    public SubTemplate toEntity(Template template, SubTemplateRequestDTO requestDTO) {
         return SubTemplate.builder()
             .title(requestDTO.getTitle())
             .template(template)
             .build();
     }
 
-    public SubTemplateCreateResponseDTO toSubTemplateCreateResponseDTO(
+    public SubTemplateCreateResponseDTO toCreateResponseDTO(
         List<SubTemplate> subTemplates) {
         List<SubTemplateResponseDTO> subTemplateResponseDTOs = new ArrayList<>();
         for (SubTemplate subTemplate : subTemplates) {
-            subTemplateResponseDTOs.add(toSubTemplateResponseDTO(subTemplate));
+            subTemplateResponseDTOs.add(toResponseDTO(subTemplate));
         }
 
         return SubTemplateCreateResponseDTO.builder()
@@ -41,7 +41,7 @@ public class SubTemplateConverter {
             .build();
     }
 
-    public SubTemplateResponseDTO toSubTemplateResponseDTO(SubTemplate subTemplate) {
+    public SubTemplateResponseDTO toResponseDTO(SubTemplate subTemplate) {
         return SubTemplateResponseDTO.builder()
             .subTemplateId(subTemplate.getSubTemplateId())
             .templateId(subTemplate.getTemplate().getTemplateId())

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/domain/SubTemplate.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/domain/SubTemplate.java
@@ -1,7 +1,15 @@
 package com.hotpack.krocs.domain.templates.domain;
 
 import com.hotpack.krocs.global.common.entity.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,17 +23,15 @@ import lombok.NoArgsConstructor;
 @Builder
 public class SubTemplate extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "sub_template_id")
-    private Long subTemplateId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "sub_template_id")
+  private Long subTemplateId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "template_id", nullable = false)
-    private Template template;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_id", nullable = false)
+  private Template template;
 
-    @Column(name = "title", nullable = false, length = 200)
-    private String title;
-
-
+  @Column(name = "title", nullable = false, length = 200)
+  private String title;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/request/SubTemplateCreateRequestDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/request/SubTemplateCreateRequestDTO.java
@@ -1,0 +1,21 @@
+package com.hotpack.krocs.domain.templates.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SubTemplateCreateRequestDTO {
+
+  @NotEmpty
+  @Schema(description = "SubTemplate 리스트")
+  List<SubTemplateRequestDTO> subTemplates;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/request/SubTemplateRequestDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/request/SubTemplateRequestDTO.java
@@ -1,0 +1,22 @@
+package com.hotpack.krocs.domain.templates.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SubTemplateRequestDTO {
+
+  @NotBlank(message = "목표 제목은 필수입니다")
+  @Size(max = 200, message = "목표 제목은 200자를 초과할 수 없습니다")
+  @Schema(description = "SubTemplate 생성 DTO", example = "퇴근하기")
+  private String title;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateCreateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateCreateResponseDTO.java
@@ -1,0 +1,17 @@
+package com.hotpack.krocs.domain.templates.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class SubTemplateCreateResponseDTO {
+
+  List<SubTemplateResponseDTO> subTemplates;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateResponseDTO.java
@@ -1,6 +1,8 @@
 package com.hotpack.krocs.domain.templates.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +12,17 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SubTemplateResponseDTO {
 
-    private final Long subTemplateId;
+  @JsonProperty("sub_template_id")
+  private final Long subTemplateId;
 
-    private final String title;
+  @JsonProperty("template_id")
+  private final Long templateId;
+
+  private final String title;
+
+  @JsonProperty("created_at")
+  private final LocalDateTime createdAt;
+
+  @JsonProperty("updated_at")
+  private final LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateResponseDTO.java
@@ -3,6 +3,7 @@ package com.hotpack.krocs.domain.templates.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,10 +22,20 @@ public class SubTemplateResponseDTO {
 
     private final String title;
 
+    @Schema(
+        description = "생성 일시",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss",
+        example = "2025-08-03T15:05:12"
+    )
     @JsonProperty("created_at")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime createdAt;
 
+    @Schema(
+        description = "수정 일시",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss",
+        example = "2025-08-03T15:05:12"
+    )
     @JsonProperty("updated_at")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime updatedAt;

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/SubTemplateResponseDTO.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.domain.templates.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
@@ -12,17 +13,19 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SubTemplateResponseDTO {
 
-  @JsonProperty("sub_template_id")
-  private final Long subTemplateId;
+    @JsonProperty("sub_template_id")
+    private final Long subTemplateId;
 
-  @JsonProperty("template_id")
-  private final Long templateId;
+    @JsonProperty("template_id")
+    private final Long templateId;
 
-  private final String title;
+    private final String title;
 
-  @JsonProperty("created_at")
-  private final LocalDateTime createdAt;
+    @JsonProperty("created_at")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime createdAt;
 
-  @JsonProperty("updated_at")
-  private final LocalDateTime updatedAt;
+    @JsonProperty("updated_at")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/SubTemplateException.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/SubTemplateException.java
@@ -1,0 +1,15 @@
+package com.hotpack.krocs.domain.templates.exception;
+
+import com.hotpack.krocs.global.common.response.exception.GeneralException;
+import lombok.Getter;
+
+@Getter
+public class SubTemplateException extends GeneralException {
+
+  private final SubTemplateExceptionType subTemplateExceptionType;
+
+  public SubTemplateException(SubTemplateExceptionType subTemplateExceptionType) {
+    super(subTemplateExceptionType);
+    this.subTemplateExceptionType = subTemplateExceptionType;
+  }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/SubTemplateExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/SubTemplateExceptionType.java
@@ -1,0 +1,53 @@
+package com.hotpack.krocs.domain.templates.exception;
+
+import com.hotpack.krocs.global.common.response.code.BaseCode;
+import com.hotpack.krocs.global.common.response.code.Reason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SubTemplateExceptionType implements BaseCode {
+  SUB_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBTEMPLATE404", "서브 탬플릿을 찾을 수 없습니다."),
+  SUB_TEMPLATE_TEMPLATE_NOTFOUND(HttpStatus.NOT_FOUND, "SUBTEMPLATE404",
+      "서브 템플릿의 상위 템플릿을 찾을 수 없습니다."),
+  SUB_TEMPLATE_TEMPLATE_ID_IS_NULL(HttpStatus.NOT_FOUND, "SUBTEMPLATE404",
+      "서브 템플릿의 상위 템플릿의 아이디가 null 입니다."),
+  SUB_TEMPLATE_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "SUBTEMPLATE400", "서브 탬플릿 제목은 필수입니다."),
+  SUB_TEMPLATE_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBTEMPLATE500",
+      "서브 탬플릿 생성에 실패했습니다."),
+  SUB_TEMPLATE_FOUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBTEMPLATE500",
+      "서브 탬플릿 조회에 실패했습니다."),
+  SUB_TEMPLATE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBTEMPLATE500",
+      "서브 탬플릿 수정에 실패했습니다."),
+  SUB_TEMPLATE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBTEMPLATE500",
+      "서브 탬플릿 삭제에 실패했습니다."),
+  SUB_TEMPLATE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "SUBTEMPLATE400", "서브 탬플릿 제목이 너무 깁니다."),
+  SUB_TEMPLATE_DUPLICATE_TITLE(HttpStatus.CONFLICT, "SUBTEMPLATE409", "동일한 제목의 서브 탬플릿이 이미 존재합니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  @Override
+  public Reason getReason() {
+    return Reason.builder()
+        .message(message)
+        .code(code)
+        .isSuccess(false)
+        .data("")
+        .build();
+  }
+
+  @Override
+  public Reason getReasonHttpStatus() {
+    return Reason.builder()
+        .message(message)
+        .code(code)
+        .isSuccess(false)
+        .httpStatus(httpStatus)
+        .data("")
+        .build();
+  }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/SubTemplateRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/SubTemplateRepositoryFacade.java
@@ -1,0 +1,22 @@
+package com.hotpack.krocs.domain.templates.facade;
+
+import com.hotpack.krocs.domain.templates.domain.SubTemplate;
+import com.hotpack.krocs.domain.templates.repository.SubTemplateRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubTemplateRepositoryFacade {
+
+  private final SubTemplateRepository subTemplateRepository;
+
+  @Transactional
+  public List<SubTemplate> saveAll(List<SubTemplate> subTemplates) {
+    return subTemplateRepository.saveAll(subTemplates);
+  }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateService.java
@@ -1,0 +1,11 @@
+package com.hotpack.krocs.domain.templates.service;
+
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
+
+public interface SubTemplateService {
+
+  SubTemplateCreateResponseDTO createSubTemplates(Long templateId,
+      SubTemplateCreateRequestDTO requestDTO,
+      Long userId);
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImpl.java
@@ -1,0 +1,51 @@
+package com.hotpack.krocs.domain.templates.service;
+
+import com.hotpack.krocs.domain.templates.converter.SubTemplateConverter;
+import com.hotpack.krocs.domain.templates.domain.SubTemplate;
+import com.hotpack.krocs.domain.templates.domain.Template;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
+import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
+import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
+import com.hotpack.krocs.domain.templates.facade.SubTemplateRepositoryFacade;
+import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubTemplateServiceImpl implements SubTemplateService {
+
+  private final TemplateRepositoryFacade templateRepositoryFacade;
+  private final SubTemplateRepositoryFacade subTemplateRepositoryFacade;
+
+  private final SubTemplateConverter subTemplateConverter;
+
+  @Override
+  public SubTemplateCreateResponseDTO createSubTemplates(Long templateId,
+      SubTemplateCreateRequestDTO requestDTO,
+      Long userId) {
+    try {
+      if (templateId == null) {
+        throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_ID_IS_NULL);
+      }
+      Template template = templateRepositoryFacade.findByTemplateId(templateId);
+      if (template == null) {
+        throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOTFOUND);
+      }
+      List<SubTemplate> subTemplates = subTemplateConverter.toSubTemplateEntityList(template,
+          requestDTO);
+      List<SubTemplate> createdSubTemplates = subTemplateRepositoryFacade.saveAll(subTemplates);
+      return subTemplateConverter.toSubTemplateCreateResponseDTO(createdSubTemplates);
+
+    } catch (SubTemplateException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("서브 템플릿 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+      throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
+    }
+  }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImpl.java
@@ -19,33 +19,36 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SubTemplateServiceImpl implements SubTemplateService {
 
-  private final TemplateRepositoryFacade templateRepositoryFacade;
-  private final SubTemplateRepositoryFacade subTemplateRepositoryFacade;
+    private final TemplateRepositoryFacade templateRepositoryFacade;
+    private final SubTemplateRepositoryFacade subTemplateRepositoryFacade;
 
-  private final SubTemplateConverter subTemplateConverter;
+    private final SubTemplateConverter subTemplateConverter;
 
-  @Override
-  public SubTemplateCreateResponseDTO createSubTemplates(Long templateId,
-      SubTemplateCreateRequestDTO requestDTO,
-      Long userId) {
-    try {
-      if (templateId == null) {
-        throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_ID_IS_NULL);
-      }
-      Template template = templateRepositoryFacade.findByTemplateId(templateId);
-      if (template == null) {
-        throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOTFOUND);
-      }
-      List<SubTemplate> subTemplates = subTemplateConverter.toSubTemplateEntityList(template,
-          requestDTO);
-      List<SubTemplate> createdSubTemplates = subTemplateRepositoryFacade.saveAll(subTemplates);
-      return subTemplateConverter.toSubTemplateCreateResponseDTO(createdSubTemplates);
+    @Override
+    public SubTemplateCreateResponseDTO createSubTemplates(Long templateId,
+        SubTemplateCreateRequestDTO requestDTO,
+        Long userId) {
+        try {
+            if (templateId == null) {
+                throw new SubTemplateException(
+                    SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_ID_IS_NULL);
+            }
+            Template template = templateRepositoryFacade.findByTemplateId(templateId);
+            if (template == null) {
+                throw new SubTemplateException(
+                    SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOTFOUND);
+            }
+            List<SubTemplate> subTemplates = subTemplateConverter.toEntityList(template,
+                requestDTO);
+            List<SubTemplate> createdSubTemplates = subTemplateRepositoryFacade.saveAll(
+                subTemplates);
+            return subTemplateConverter.toCreateResponseDTO(createdSubTemplates);
 
-    } catch (SubTemplateException e) {
-      throw e;
-    } catch (Exception e) {
-      log.error("서브 템플릿 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-      throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
+        } catch (SubTemplateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("서브 템플릿 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
+        }
     }
-  }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ spring:
     import: optional:file:application-secret.yml
   jpa:
     hibernate:
-      ddl-auto: update  # or validate, create, create-drop
+      ddl-auto: none  # or validate, create, create-drop
     show-sql: true
     properties:
       hibernate:

--- a/backend/src/main/resources/db/changelog/changes/002-remove-unused-columns.yaml
+++ b/backend/src/main/resources/db/changelog/changes/002-remove-unused-columns.yaml
@@ -1,0 +1,71 @@
+databaseChangeLog:
+
+  # ─────────── sub_goals.energy ───────────
+  - changeSet:
+      id: 002-01-drop-sub_goals-energy
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: sub_goals
+            columnName: energy
+      changes:
+        - dropColumn:
+            tableName: sub_goals
+            columnName: energy
+
+  # ───────── sub_templates.energy ─────────
+  - changeSet:
+      id: 002-02-drop-sub_templates-energy
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: sub_templates
+            columnName: energy
+      changes:
+        - dropColumn:
+            tableName: sub_templates
+            columnName: energy
+
+  # ─────── sub_templates.is_completed ───────
+  - changeSet:
+      id: 002-03-drop-sub_templates-is_completed
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: sub_templates
+            columnName: is_completed
+      changes:
+        - dropColumn:
+            tableName: sub_templates
+            columnName: is_completed
+
+  # ─────────── templates.repeat ───────────
+  - changeSet:
+      id: 002-04-drop-templates-repeat
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: templates
+            columnName: repeat
+      changes:
+        - dropColumn:
+            tableName: templates
+            columnName: repeat
+
+  # ──────── templates.is_completed ────────
+  - changeSet:
+      id: 002-05-drop-templates-is_completed
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: templates
+            columnName: is_completed
+      changes:
+        - dropColumn:
+            tableName: templates
+            columnName: is_completed

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,7 +2,11 @@ databaseChangeLog:
   - include:
       file: db/changelog/changes/001-initial-schema.yaml
       relativeToChangelogFile: false
-  
+
+  - include:
+      file: db/changelog/changes/002-remove-unused-columns.yaml
+      relativeToChangelogFile: false
+
   # 추가 마이그레이션 파일들은 여기에 include
   # - include:
   #     file: db/changelog/changes/002-add-new-table.yaml

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverterTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverterTest.java
@@ -1,0 +1,114 @@
+package com.hotpack.krocs.domain.templates.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hotpack.krocs.domain.templates.domain.SubTemplate;
+import com.hotpack.krocs.domain.templates.domain.Template;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
+import com.hotpack.krocs.global.common.entity.Priority;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class SubTemplateConverterTest {
+
+  @Mock
+  private SubTemplateConverter subTemplateConverter;
+
+  private SubTemplateCreateRequestDTO validCreateRequestDTO;
+  private SubTemplateRequestDTO validSubTemplateRequestDTO;
+  private SubTemplate validSubTemplate;
+  private Template validTemplate;
+
+
+  @BeforeEach
+  void setup() {
+    // given
+    subTemplateConverter = new SubTemplateConverter();
+
+    validTemplate = Template.builder()
+        .templateId(1L)
+        .priority(Priority.HIGH)
+        .duration(10)
+        .build();
+
+    validSubTemplateRequestDTO = SubTemplateRequestDTO.builder()
+        .title("테스트입니다")
+        .build();
+
+    validCreateRequestDTO = SubTemplateCreateRequestDTO.builder()
+        .subTemplates(List.of(validSubTemplateRequestDTO))
+        .build();
+
+    validSubTemplate = SubTemplate.builder()
+        .subTemplateId(1L)
+        .template(validTemplate)
+        .title("테스트입니다")
+        .build();
+  }
+
+
+  @Test
+  @DisplayName("SubTemplateCreateRequestDTO를 List<SubTemplate>로 변환")
+  void toSubTemplateEntityList_Success() {
+    // when
+    List<SubTemplate> subTemplates = subTemplateConverter.toSubTemplateEntityList(validTemplate,
+        validCreateRequestDTO);
+
+    // then
+    assertThat(subTemplates.size()).isEqualTo(1);
+    SubTemplate createdSubTemplate = subTemplates.getFirst();
+    assertThat(createdSubTemplate.getTemplate()).isEqualTo(validSubTemplate.getTemplate());
+    assertThat(createdSubTemplate.getTitle()).isEqualTo(validSubTemplate.getTitle());
+  }
+
+  @Test
+  @DisplayName("SubTemplateRequestDTO를 SubTemplate로 변환")
+  void toSubTemplateEntity_Success() {
+    // when
+    SubTemplate createdSubTemplate = subTemplateConverter.toSubTemplateEntity(validTemplate,
+        validSubTemplateRequestDTO);
+
+    // then
+    assertThat(createdSubTemplate.getTemplate()).isEqualTo(validSubTemplate.getTemplate());
+    assertThat(createdSubTemplate.getTitle()).isEqualTo(validSubTemplate.getTitle());
+  }
+
+  @Test
+  @DisplayName("List<SubTemplate>를 SubTemplateCreateResponseDTO로 변환")
+  void toSubTemplateCreateResponseDTO_Success() {
+    // when
+    SubTemplateCreateResponseDTO responseDTO = subTemplateConverter.toSubTemplateCreateResponseDTO(
+        List.of(validSubTemplate));
+
+    // then
+    assertThat(responseDTO.getSubTemplates().size()).isEqualTo(1);
+    SubTemplateResponseDTO subTemplateResponseDTO = responseDTO.getSubTemplates().getFirst();
+    assertThat(subTemplateResponseDTO.getSubTemplateId()).isEqualTo(
+        validSubTemplate.getSubTemplateId());
+    assertThat(subTemplateResponseDTO.getTemplateId()).isEqualTo(
+        validSubTemplate.getTemplate().getTemplateId());
+    assertThat(subTemplateResponseDTO.getTitle()).isEqualTo(validSubTemplate.getTitle());
+  }
+
+  @Test
+  @DisplayName("SubTemplate을 SubTemplateResponseDTO로 변환")
+  void toSubTemplateResponseDTO_Success() {
+    // when
+    SubTemplateResponseDTO responseDTO = subTemplateConverter.toSubTemplateResponseDTO(
+        validSubTemplate);
+
+    // then
+    assertThat(responseDTO.getSubTemplateId()).isEqualTo(
+        validSubTemplate.getSubTemplateId());
+    assertThat(responseDTO.getTemplateId()).isEqualTo(
+        validSubTemplate.getTemplate().getTemplateId());
+    assertThat(responseDTO.getTitle()).isEqualTo(validSubTemplate.getTitle());
+  }
+  
+}

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverterTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/converter/SubTemplateConverterTest.java
@@ -17,98 +17,98 @@ import org.mockito.Mock;
 
 class SubTemplateConverterTest {
 
-  @Mock
-  private SubTemplateConverter subTemplateConverter;
+    @Mock
+    private SubTemplateConverter subTemplateConverter;
 
-  private SubTemplateCreateRequestDTO validCreateRequestDTO;
-  private SubTemplateRequestDTO validSubTemplateRequestDTO;
-  private SubTemplate validSubTemplate;
-  private Template validTemplate;
-
-
-  @BeforeEach
-  void setup() {
-    // given
-    subTemplateConverter = new SubTemplateConverter();
-
-    validTemplate = Template.builder()
-        .templateId(1L)
-        .priority(Priority.HIGH)
-        .duration(10)
-        .build();
-
-    validSubTemplateRequestDTO = SubTemplateRequestDTO.builder()
-        .title("테스트입니다")
-        .build();
-
-    validCreateRequestDTO = SubTemplateCreateRequestDTO.builder()
-        .subTemplates(List.of(validSubTemplateRequestDTO))
-        .build();
-
-    validSubTemplate = SubTemplate.builder()
-        .subTemplateId(1L)
-        .template(validTemplate)
-        .title("테스트입니다")
-        .build();
-  }
+    private SubTemplateCreateRequestDTO validCreateRequestDTO;
+    private SubTemplateRequestDTO validSubTemplateRequestDTO;
+    private SubTemplate validSubTemplate;
+    private Template validTemplate;
 
 
-  @Test
-  @DisplayName("SubTemplateCreateRequestDTO를 List<SubTemplate>로 변환")
-  void toSubTemplateEntityList_Success() {
-    // when
-    List<SubTemplate> subTemplates = subTemplateConverter.toSubTemplateEntityList(validTemplate,
-        validCreateRequestDTO);
+    @BeforeEach
+    void setup() {
+        // given
+        subTemplateConverter = new SubTemplateConverter();
 
-    // then
-    assertThat(subTemplates.size()).isEqualTo(1);
-    SubTemplate createdSubTemplate = subTemplates.getFirst();
-    assertThat(createdSubTemplate.getTemplate()).isEqualTo(validSubTemplate.getTemplate());
-    assertThat(createdSubTemplate.getTitle()).isEqualTo(validSubTemplate.getTitle());
-  }
+        validTemplate = Template.builder()
+            .templateId(1L)
+            .priority(Priority.HIGH)
+            .duration(10)
+            .build();
 
-  @Test
-  @DisplayName("SubTemplateRequestDTO를 SubTemplate로 변환")
-  void toSubTemplateEntity_Success() {
-    // when
-    SubTemplate createdSubTemplate = subTemplateConverter.toSubTemplateEntity(validTemplate,
-        validSubTemplateRequestDTO);
+        validSubTemplateRequestDTO = SubTemplateRequestDTO.builder()
+            .title("테스트입니다")
+            .build();
 
-    // then
-    assertThat(createdSubTemplate.getTemplate()).isEqualTo(validSubTemplate.getTemplate());
-    assertThat(createdSubTemplate.getTitle()).isEqualTo(validSubTemplate.getTitle());
-  }
+        validCreateRequestDTO = SubTemplateCreateRequestDTO.builder()
+            .subTemplates(List.of(validSubTemplateRequestDTO))
+            .build();
 
-  @Test
-  @DisplayName("List<SubTemplate>를 SubTemplateCreateResponseDTO로 변환")
-  void toSubTemplateCreateResponseDTO_Success() {
-    // when
-    SubTemplateCreateResponseDTO responseDTO = subTemplateConverter.toSubTemplateCreateResponseDTO(
-        List.of(validSubTemplate));
+        validSubTemplate = SubTemplate.builder()
+            .subTemplateId(1L)
+            .template(validTemplate)
+            .title("테스트입니다")
+            .build();
+    }
 
-    // then
-    assertThat(responseDTO.getSubTemplates().size()).isEqualTo(1);
-    SubTemplateResponseDTO subTemplateResponseDTO = responseDTO.getSubTemplates().getFirst();
-    assertThat(subTemplateResponseDTO.getSubTemplateId()).isEqualTo(
-        validSubTemplate.getSubTemplateId());
-    assertThat(subTemplateResponseDTO.getTemplateId()).isEqualTo(
-        validSubTemplate.getTemplate().getTemplateId());
-    assertThat(subTemplateResponseDTO.getTitle()).isEqualTo(validSubTemplate.getTitle());
-  }
 
-  @Test
-  @DisplayName("SubTemplate을 SubTemplateResponseDTO로 변환")
-  void toSubTemplateResponseDTO_Success() {
-    // when
-    SubTemplateResponseDTO responseDTO = subTemplateConverter.toSubTemplateResponseDTO(
-        validSubTemplate);
+    @Test
+    @DisplayName("SubTemplateCreateRequestDTO를 List<SubTemplate>로 변환")
+    void toEntityList_Success() {
+        // when
+        List<SubTemplate> subTemplates = subTemplateConverter.toEntityList(validTemplate,
+            validCreateRequestDTO);
 
-    // then
-    assertThat(responseDTO.getSubTemplateId()).isEqualTo(
-        validSubTemplate.getSubTemplateId());
-    assertThat(responseDTO.getTemplateId()).isEqualTo(
-        validSubTemplate.getTemplate().getTemplateId());
-    assertThat(responseDTO.getTitle()).isEqualTo(validSubTemplate.getTitle());
-  }
-  
+        // then
+        assertThat(subTemplates.size()).isEqualTo(1);
+        SubTemplate createdSubTemplate = subTemplates.getFirst();
+        assertThat(createdSubTemplate.getTemplate()).isEqualTo(validSubTemplate.getTemplate());
+        assertThat(createdSubTemplate.getTitle()).isEqualTo(validSubTemplate.getTitle());
+    }
+
+    @Test
+    @DisplayName("SubTemplateRequestDTO를 SubTemplate로 변환")
+    void toEntity_Success() {
+        // when
+        SubTemplate createdSubTemplate = subTemplateConverter.toEntity(validTemplate,
+            validSubTemplateRequestDTO);
+
+        // then
+        assertThat(createdSubTemplate.getTemplate()).isEqualTo(validSubTemplate.getTemplate());
+        assertThat(createdSubTemplate.getTitle()).isEqualTo(validSubTemplate.getTitle());
+    }
+
+    @Test
+    @DisplayName("List<SubTemplate>를 SubTemplateCreateResponseDTO로 변환")
+    void toCreateResponseDTO_Success() {
+        // when
+        SubTemplateCreateResponseDTO responseDTO = subTemplateConverter.toCreateResponseDTO(
+            List.of(validSubTemplate));
+
+        // then
+        assertThat(responseDTO.getSubTemplates().size()).isEqualTo(1);
+        SubTemplateResponseDTO subTemplateResponseDTO = responseDTO.getSubTemplates().getFirst();
+        assertThat(subTemplateResponseDTO.getSubTemplateId()).isEqualTo(
+            validSubTemplate.getSubTemplateId());
+        assertThat(subTemplateResponseDTO.getTemplateId()).isEqualTo(
+            validSubTemplate.getTemplate().getTemplateId());
+        assertThat(subTemplateResponseDTO.getTitle()).isEqualTo(validSubTemplate.getTitle());
+    }
+
+    @Test
+    @DisplayName("SubTemplate을 SubTemplateResponseDTO로 변환")
+    void toResponseDTO_Success() {
+        // when
+        SubTemplateResponseDTO responseDTO = subTemplateConverter.toResponseDTO(
+            validSubTemplate);
+
+        // then
+        assertThat(responseDTO.getSubTemplateId()).isEqualTo(
+            validSubTemplate.getSubTemplateId());
+        assertThat(responseDTO.getTemplateId()).isEqualTo(
+            validSubTemplate.getTemplate().getTemplateId());
+        assertThat(responseDTO.getTitle()).isEqualTo(validSubTemplate.getTitle());
+    }
+
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImplTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImplTest.java
@@ -1,0 +1,132 @@
+package com.hotpack.krocs.domain.templates.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.hotpack.krocs.domain.templates.converter.SubTemplateConverter;
+import com.hotpack.krocs.domain.templates.domain.SubTemplate;
+import com.hotpack.krocs.domain.templates.domain.Template;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
+import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
+import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
+import com.hotpack.krocs.domain.templates.facade.SubTemplateRepositoryFacade;
+import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
+import com.hotpack.krocs.global.common.entity.Priority;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubTemplateServiceImplTest {
+
+  @Spy
+  private SubTemplateConverter subTemplateConverter;
+  @Mock
+  private SubTemplateRepositoryFacade subTemplateRepositoryFacade;
+  @Mock
+  private TemplateRepositoryFacade templateRepositoryFacade;
+
+  @InjectMocks
+  private SubTemplateServiceImpl subTemplateService;
+
+  private SubTemplateCreateRequestDTO validCreateRequestDTO;
+  private SubTemplateRequestDTO validSubTemplateRequestDTO;
+  private SubTemplate validSubTemplate;
+  private Template validTemplate;
+
+
+  @BeforeEach
+  void setup() {
+    // given
+    validTemplate = Template.builder()
+        .templateId(1L)
+        .priority(Priority.HIGH)
+        .duration(10)
+        .build();
+
+    validSubTemplateRequestDTO = SubTemplateRequestDTO.builder()
+        .title("테스트입니다")
+        .build();
+
+    validCreateRequestDTO = SubTemplateCreateRequestDTO.builder()
+        .subTemplates(List.of(validSubTemplateRequestDTO))
+        .build();
+
+    validSubTemplate = SubTemplate.builder()
+        .subTemplateId(1L)
+        .template(validTemplate)
+        .title("테스트입니다")
+        .build();
+  }
+
+  // ======= CREATE =======
+
+  @Test
+  @DisplayName("서브 템플릿 생성 성공")
+  void createSubTemplates_Success() {
+    // when
+    when(templateRepositoryFacade.findByTemplateId(1L)).thenReturn(validTemplate);
+    when(subTemplateRepositoryFacade.saveAll(any())).thenReturn(List.of(validSubTemplate));
+
+    SubTemplateCreateResponseDTO responseDTO = subTemplateService.createSubTemplates(1L,
+        validCreateRequestDTO, 1L);
+
+    // then
+    SubTemplateResponseDTO subTemplateResponseDTO = responseDTO.getSubTemplates().getFirst();
+    assertThat(subTemplateResponseDTO.getSubTemplateId()).isEqualTo(1L);
+    assertThat(subTemplateResponseDTO.getTemplateId()).isEqualTo(1L);
+    assertThat(subTemplateResponseDTO.getTitle()).isEqualTo("테스트입니다");
+  }
+
+  @Test
+  @DisplayName("서브 템플릿 생성 실패 - templateId가 null인 경우")
+  void createSubTemplates_templateIdIsNull() {
+    // when
+    SubTemplateException exception = assertThrows(SubTemplateException.class,
+        () -> subTemplateService.createSubTemplates(null, validCreateRequestDTO, 1L));
+
+    // then
+    assertThat(exception.getSubTemplateExceptionType()).isEqualTo(
+        SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_ID_IS_NULL);
+  }
+
+  @Test
+  @DisplayName("서브 템플릿 생성 실패 - template가 null인 경우")
+  void createSubTemplates_templateIsNull() {
+    // when
+    when(templateRepositoryFacade.findByTemplateId(1L)).thenReturn(null);
+
+    SubTemplateException exception = assertThrows(SubTemplateException.class,
+        () -> subTemplateService.createSubTemplates(1L, validCreateRequestDTO, 1L));
+
+    // then
+    assertThat(exception.getSubTemplateExceptionType()).isEqualTo(
+        SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOTFOUND);
+  }
+
+  @Test
+  @DisplayName("서브 템플릿 생성 실패 - 예상치 못한 오류 발생")
+  void createSubTemplates_UnknownException() {
+    // when
+    when(templateRepositoryFacade.findByTemplateId(1L)).thenThrow(new RuntimeException());
+
+    SubTemplateException exception = assertThrows(SubTemplateException.class,
+        () -> subTemplateService.createSubTemplates(1L, validCreateRequestDTO, 1L));
+
+    // then
+    assertThat(exception.getSubTemplateExceptionType()).isEqualTo(
+        SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
+  }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #40

## 🚀 작업 내용
- [x] SubTemplateCreateResquestDTO 작성
- [x] SubTemplateConverter.toSubTemplateEntity(requestDTO) 구현
- [x] SubTemplateCreateResponseDTO 작성
- [x] SubTemplateConverter.toSubTemplateCreateResponseDTO(subTemplate) 구현
- [x] SubTemplateRepository.save() 작성
- [x] SubTemplateFacade.save() 구현
- [x] SubTemplateService.createSubTemplate() 구현
- [x] TemplateController.createSubTemplate() 구현
- [x] SubTemplateException 및 SubTemplateExceptionType 작성
- [x] test 코드 작성
- [x] resources.db.changelog.changes 추가


## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- DB 속성 최신회를 위해 `002-remove-unused-columns.yaml` 을 작성했습니다.(duration 제거는 미추가)
- 부족한 유효성 검증 및 리팩토링 사항
- 테스트 코드 통과 여부

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
20분+