### PR TITLE
[feat] 세부일정(SubPlans) 조회 API

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
@@ -1,11 +1,10 @@
 package com.hotpack.krocs.domain.plans.controller;
 
 
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
+import com.hotpack.krocs.domain.plans.dto.response.SubPlanResponseDTO;
 import com.hotpack.krocs.domain.plans.exception.SubPlanException;
 import com.hotpack.krocs.domain.plans.exception.SubPlanExceptionType;
 import com.hotpack.krocs.domain.plans.service.SubPlanService;
@@ -52,6 +51,24 @@ public class SubPlanController {
             throw e;
         } catch (Exception e) {
             throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_CREATE_FAILED);
+        }
+    }
+
+    @Operation(summary = "특정 소계획 조회", description = "특정 소계획을 조회합니다")
+    @GetMapping("/{planId}/subplans/{subPlanId}")
+    public ApiResponse<SubPlanResponseDTO> getSubPlan(
+        @PathVariable @Parameter(description = "Plan ID", example = "1")
+        Long planId,
+        @PathVariable @Parameter(description = "SubPlan ID", example = "23")
+        Long subPlanId
+    ) {
+        try {
+            SubPlanResponseDTO response = subPlanService.getSubPlan(planId, subPlanId);
+            return ApiResponse.success(response);
+        } catch (SubPlanException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_READ_FAILED);
         }
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
@@ -1,8 +1,11 @@
 package com.hotpack.krocs.domain.plans.controller;
 
 
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
+import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
 import com.hotpack.krocs.domain.plans.exception.SubPlanException;
 import com.hotpack.krocs.domain.plans.exception.SubPlanExceptionType;
 import com.hotpack.krocs.domain.plans.service.SubPlanService;
@@ -19,9 +22,8 @@ public class SubPlanController {
 
     private final SubPlanService subPlanService;
 
-
     @Operation(summary = "소계획 생성", description = "소계획을 생성합니다.")
-    @PostMapping("plans/{planId}/subplans")
+    @PostMapping("/plans/{planId}/subplans")
     public ApiResponse<SubPlanCreateResponseDTO> createSubPlans(
         @PathVariable @Parameter(description = "Plan ID", example = "1")
         Long planId,
@@ -37,4 +39,21 @@ public class SubPlanController {
             throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_CREATE_FAILED);
         }
     }
+
+    @Operation(summary = "특정 plan 소계획 리스트 조회", description = "특정 plan의 소계획 리스트를 조회합니다.")
+    @GetMapping("/{planId}/subplans")
+    public ApiResponse<SubPlanListResponseDTO> getSubGoals(
+        @PathVariable @Parameter(description = "Plan ID", example = "1") Long planId
+    ) {
+        try {
+            SubPlanListResponseDTO response = subPlanService.getAllSubPlans(planId);
+            return ApiResponse.success(response);
+        } catch (SubPlanException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_CREATE_FAILED);
+        }
+    }
+
+
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
@@ -12,7 +12,12 @@ import com.hotpack.krocs.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -41,7 +46,7 @@ public class SubPlanController {
 
     @Operation(summary = "특정 plan 소계획 리스트 조회", description = "특정 plan의 소계획 리스트를 조회합니다.")
     @GetMapping("/{planId}/subplans")
-    public ApiResponse<SubPlanListResponseDTO> getSubGoals(
+    public ApiResponse<SubPlanListResponseDTO> getAllSubPlans(
         @PathVariable @Parameter(description = "Plan ID", example = "1") Long planId
     ) {
         try {

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanListResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanListResponseDTO.java
@@ -1,7 +1,6 @@
 package com.hotpack.krocs.domain.plans.dto.response;
 
 
-
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +8,6 @@ import lombok.Getter;
 @Builder
 @Getter
 public class SubPlanListResponseDTO {
-    private List<SubPlanResponseDTO> subPlans;
 
+    private List<SubPlanResponseDTO> subPlans;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanListResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.hotpack.krocs.domain.plans.dto.response;
+
+
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SubPlanListResponseDTO {
+    private List<SubPlanResponseDTO> subPlans;
+
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanListResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanListResponseDTO.java
@@ -1,6 +1,8 @@
 package com.hotpack.krocs.domain.plans.dto.response;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,5 +11,7 @@ import lombok.Getter;
 @Getter
 public class SubPlanListResponseDTO {
 
+    @JsonProperty("sub_plans")
+    @Schema(description = "SubPlan 리스트")
     private List<SubPlanResponseDTO> subPlans;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/facade/SubPlanRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/facade/SubPlanRepositoryFacade.java
@@ -46,7 +46,6 @@ public class SubPlanRepositoryFacade {
         if (subPlan == null) {
             throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_NOT_FOUND);
         }
-
         return subPlan;
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanService.java
@@ -5,6 +5,7 @@ import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
+import com.hotpack.krocs.domain.plans.dto.response.SubPlanResponseDTO;
 import org.springframework.stereotype.Service;
 
 public interface SubPlanService {
@@ -13,5 +14,7 @@ public interface SubPlanService {
         SubPlanCreateRequestDTO subPlanCreateRequestDTO);
 
     SubPlanListResponseDTO getAllSubPlans(Long planId);
+
+    SubPlanResponseDTO getSubPlan(Long planId, Long subPlanId);
 }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanService.java
@@ -1,13 +1,17 @@
 package com.hotpack.krocs.domain.plans.service;
 
 
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
+import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
 import org.springframework.stereotype.Service;
 
 public interface SubPlanService {
 
     SubPlanCreateResponseDTO createSubPlans(Long planId,
         SubPlanCreateRequestDTO subPlanCreateRequestDTO);
+
+    SubPlanListResponseDTO getAllSubPlans(Long planId);
 }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
@@ -7,6 +7,7 @@ import com.hotpack.krocs.domain.plans.domain.SubPlan;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
+import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanResponseDTO;
 import com.hotpack.krocs.domain.plans.exception.SubPlanException;
 import com.hotpack.krocs.domain.plans.exception.SubPlanExceptionType;
@@ -71,6 +72,32 @@ public class SubPlanServiceImpl implements SubPlanService {
             if (subPlanRequestDTO.getTitle().length() > 200) {
                 throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_TITLE_TOO_LONG);
             }
+        }
+    }
+
+    @Override
+    public SubPlanListResponseDTO getAllSubPlans(Long planId) {
+        try {
+            if (planId == null) {
+                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
+            }
+
+            Plan plan = planRepositoryFacade.findPlanById(planId);
+
+            List<SubPlan> subPlans = subPlanRepositoryFacade.findSubPlansByPlan(plan);
+
+            // 빈 리스트는 정상 응답으로 간주하고 그대로 반환
+            List<SubPlanResponseDTO> subPlanResponseDTOs = subPlanConverter.toSubPlanResponseListDTO(
+                subPlans);
+
+            return SubPlanListResponseDTO.builder()
+                .subPlans(subPlanResponseDTOs)
+                .build();
+        } catch (SubPlanException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("소계획 전체 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_READ_FAILED);
         }
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
@@ -101,5 +101,33 @@ public class SubPlanServiceImpl implements SubPlanService {
         }
     }
 
+    @Override
+    public SubPlanResponseDTO getSubPlan(Long planId, Long subPlanId) {
+        try {
+            if (planId == null) {
+                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
+            }
+            if (subPlanId == null) {
+                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
+            }
+
+            Plan plan = planRepositoryFacade.findPlanById(planId);
+            List<SubPlan> subPlans = subPlanRepositoryFacade.findSubPlansByPlan(plan);
+            SubPlan subPlan = subPlanRepositoryFacade.findSubPlanBySubPlanId(subPlanId);
+
+            if (!subPlans.contains(subPlan)) {
+                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_NOT_BELONG_TO_PLAN);
+            }
+
+            return subPlanConverter.toSubPlanResponseDTO(subPlan);
+
+        } catch (SubPlanException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("소계획 단건 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_READ_FAILED);
+        }
+    }
+
 
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceTest.java
@@ -206,5 +206,51 @@ class SubPlanServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.getSubPlans()).isEmpty();
     }
+
+    @Test
+    @DisplayName("소계획 단건 조회 - planId가 null인 경우")
+    void getSubPlan_planIdIsNull() {
+        // when & then
+        assertThatThrownBy(() -> subPlanService.getSubPlan(null, 1L))
+            .isInstanceOf(SubPlanException.class)
+            .hasFieldOrPropertyWithValue("subPlanExceptionType", SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
+    }
+
+    @Test
+    @DisplayName("소계획 단건 조회 - subPlanId가 null인 경우")
+    void getSubPlan_subPlanIdIsNull() {
+        // when & then
+        assertThatThrownBy(() -> subPlanService.getSubPlan(1L, null))
+            .isInstanceOf(SubPlanException.class)
+            .hasFieldOrPropertyWithValue("subPlanExceptionType", SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
+    }
+
+    @Test
+    @DisplayName("소계획 단건 조회 - 해당 소계획이 주계획에 포함되지 않은 경우")
+    void getSubPlan_subPlanNotBelongToPlan() {
+        // given
+        SubPlan otherSubPlan = SubPlan.builder().subPlanId(2L).title("다른 소계획").build();
+
+        when(planRepositoryFacade.findPlanById(1L)).thenReturn(validPlan);
+        when(subPlanRepositoryFacade.findSubPlansByPlan(validPlan)).thenReturn(List.of(validSubPlan));
+        when(subPlanRepositoryFacade.findSubPlanBySubPlanId(2L)).thenReturn(otherSubPlan);
+
+        // when & then
+        assertThatThrownBy(() -> subPlanService.getSubPlan(1L, 2L))
+            .isInstanceOf(SubPlanException.class)
+            .hasFieldOrPropertyWithValue("subPlanExceptionType", SubPlanExceptionType.SUB_PLAN_NOT_BELONG_TO_PLAN);
+    }
+
+    @Test
+    @DisplayName("소계획 단건 조회 - 예기치 못한 예외 발생 시")
+    void getSubPlan_UnexpectedException() {
+        // given
+        when(planRepositoryFacade.findPlanById(1L)).thenThrow(new RuntimeException("DB error"));
+
+        // when & then
+        assertThatThrownBy(() -> subPlanService.getSubPlan(1L, 1L))
+            .isInstanceOf(SubPlanException.class)
+            .hasFieldOrPropertyWithValue("subPlanExceptionType", SubPlanExceptionType.SUB_PLAN_READ_FAILED);
+    }
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #48

## 🚀 작업 내용
- [x] 모든 일정 조회 getPlans
- [x] 특정 일정 ID로 조회 getPlanById
- [x] 테스트코드

## 🔍 리뷰 요청 사항 및 공유자료
테스트코드 성공, subplans 중 plan이 관여하는 내용들은 planController Service 등등... plan쪽으로 옮기는게 맞는지?

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
20분 +
