### PR TITLE
[bug] duplicate key 에러

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/global/config/DevTokenBootstrap.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/config/DevTokenBootstrap.java
@@ -43,32 +43,44 @@ public class DevTokenBootstrap {
 
     @PostConstruct
     public void init() {
-
-        UserRole role;
         try {
-            role = UserRole.valueOf(bootstrapUserRole.toUpperCase());
+            UserRole role;
+            try {
+                role = UserRole.valueOf(bootstrapUserRole.toUpperCase());
+            } catch (Exception e) {
+                role = UserRole.USER;
+            }
+            final UserRole resolvedRole = role;
+
+            User user;
+            try {
+                user = userRepository.findUsersByEmailAndStatus(bootstrapUserEmail, Status.ACTIVE)
+                    .orElseGet(() -> userRepository.save(User.builder()
+                        .name(bootstrapUserName)
+                        .email(bootstrapUserEmail)
+                        .password("{noop}dev")
+                        .role(resolvedRole)
+                        .accountType(AccountType.LOCAL)
+                        .build()));
+            } catch (Exception e) {
+                user = userRepository.findUsersByEmailAndStatus(bootstrapUserEmail, Status.ACTIVE)
+                    .orElse(null);
+                if (user == null) {
+                    System.err.println("Failed to create or find user: " + bootstrapUserEmail);
+                    return;
+                }
+            }
+
+            UserSession session = UserSession.of(String.valueOf(user.getUserId()), bootstrapUserName,
+                Set.of(resolvedRole));
+            try {
+                String json = objectMapper.writeValueAsString(session);
+                stringRedisTemplate.opsForValue()
+                    .set("auth:token:" + bootstrapToken, json, Duration.ofDays(7));
+            } catch (JsonProcessingException e) {
+            }
         } catch (Exception e) {
-            role = UserRole.USER;
-        }
-        final UserRole resolvedRole = role;
-
-        User user = userRepository.findUsersByEmailAndStatus(bootstrapUserEmail, Status.ACTIVE)
-            .orElseGet(() -> userRepository.save(User.builder()
-                .name(bootstrapUserName)
-                .email(bootstrapUserEmail)
-                .password("{noop}dev")
-                .role(resolvedRole)
-                .accountType(AccountType.LOCAL)
-                .build()));
-
-        UserSession session = UserSession.of(String.valueOf(user.getUserId()), bootstrapUserName,
-            Set.of(role));
-        try {
-            String json = objectMapper.writeValueAsString(session);
-            stringRedisTemplate.opsForValue()
-                .set("auth:token:" + bootstrapToken, json, Duration.ofDays(7));
-        } catch (JsonProcessingException e) {
-            // ignore
+            System.err.println("DevTokenBootstrap initialization failed: " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #103 

## 📝 수정 요약
duplicate key 에러

- 🚨 문제점
    - DevTokenBootstrap 클래스에서 애플리케이션 시작 시마다 개발용 사용자([dev@krocs.local](mailto:dev@krocs.local)) 생성을 시도하여 중복 키 제약 조건 위반 발생
    - 중복 키 에러로 인한 애플리케이션 시작 실패 및 무한 재시작 루프 발생

- 🔍 원인 분석
    - 기존 유저가 ACTIVE 상태가 아닌 경우 findUsersByEmailAndStatus 메서드가 찾지 못함
    - orElseGet 내부에서 userRepository.save() 실행 시 동시성 문제로 중복 삽입 시도
    - 예외 처리 부재로 인한 애플리케이션 컨텍스트 초기화 실패

- 💡 해결 방법
    - try-catch 블록으로 중복 키 예외 처리 추가
    - 예외 발생 시 기존 사용자 재조회 로직 구현
    - 전체 메서드를 try-catch로 감싸 예외 발생 시 안전한 종료 처리
    - 변수 스코프 문제 해결 (resolvedRole 사용)

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
5분