### PR TITLE
[feat] OAuth2 기반 구글 로그인 및 에러 핸들링 구현

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
@@ -19,7 +19,7 @@ public enum ErrorStatus implements BaseCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL405", "허용되지 않는 메서드"),
     CONFLICT(HttpStatus.CONFLICT, "GLOBAL409", "리소스 충돌"),
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "GLOBAL415", "지원하지 않는 미디어 타입"),
-    
+
     // 검증 에러
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION400", "입력값 검증 실패"),
     BAD_REQUEST_BODY(HttpStatus.BAD_REQUEST, "BAD_REQUEST_BODY400", "잘못된 데이터 타입"),
@@ -36,21 +36,21 @@ public enum ErrorStatus implements BaseCode {
     @Override
     public Reason getReason() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
     }
 
     @Override
     public Reason getReasonHttpStatus() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data("")
+            .build();
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
@@ -27,7 +27,9 @@ public enum ErrorStatus implements BaseCode {
     // 비즈니스 로직 에러
     BUSINESS_LOGIC_ERROR(HttpStatus.BAD_REQUEST, "BUSINESS400", "비즈니스 로직 오류"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE404", "요청한 리소스를 찾을 수 없습니다"),
-    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "DUPLICATE409", "중복된 리소스입니다");
+    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "DUPLICATE409", "중복된 리소스입니다"),
+    OAUTH2_SESSION_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAUTH2_500",
+        "세션 직렬화에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/exception/CustomOAuth2AuthenticationException.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/exception/CustomOAuth2AuthenticationException.java
@@ -1,0 +1,15 @@
+package com.hotpack.krocs.global.security.oauth2.exception;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+public class CustomOAuth2AuthenticationException extends OAuth2AuthenticationException {
+
+    public CustomOAuth2AuthenticationException(OAuth2ErrorType errorType) {
+        super(new OAuth2Error(
+            errorType.getCode(),
+            errorType.getMessage(),
+            errorType.getUrl()
+        ));
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/exception/OAuth2ErrorType.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/exception/OAuth2ErrorType.java
@@ -1,0 +1,41 @@
+package com.hotpack.krocs.global.security.oauth2.exception;
+
+public enum OAuth2ErrorType {
+    PROVIDER_UNAVAILABLE("provider_unavailable", "지원하지 않는 로그인 방식입니다.", null),
+    GOOGLE_ACCOUNT_ID_MISSING("google_account_id_missing", "구글 로그인 중 필수 정보가 누락되었습니다.(accountId)",
+        null),
+    GOOGLE_NAME_MISSING("google_name_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(name)",
+        null),
+    KAKAO_ACCOUNT_ID_MISSING("kakao_account_id_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(accountId)",
+        null),
+    KAKAO_NAME_MISSING("kakao_name_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(name)", null),
+    KAKAO_KAKAO_ACCOUNT_MISSING("kakao_kakao_account_missing",
+        "카카로 로그인 중 필수 정보가 누락되었습니다.(kakao_account)", null),
+    KAKAO_PROFILE_MISSING("kakao_profile_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(profile)", null),
+    NAVER_RESPONSE_MISSING("naver_response_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(response)",
+        null),
+    NAVER_ACCOUNT_ID_MISSING("naver_account_id_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(accountId)",
+        null),
+    NAVER_NAME_MISSING("naver_name_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(name)",
+        null);
+
+    private String code;
+    private String message;
+    private String url;
+
+    OAuth2ErrorType(String code, String message, String url) {
+
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -8,6 +8,8 @@ import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.domain.enums.AccountType;
 import com.hotpack.krocs.domain.user.repository.UserRepository;
 import com.hotpack.krocs.global.common.entity.Status;
+import com.hotpack.krocs.global.common.response.code.resultCode.ErrorStatus;
+import com.hotpack.krocs.global.common.response.exception.GeneralException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -43,31 +45,31 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         User user = findOrCreateUser(authentication);
         // 클라이언트에게 AUTH-TOKEN 추출
         Cookie[] cookies = request.getCookies();
-        String token = findToken(cookies);
+        String authToken = findAuthToken(cookies);
 
         // 클라이언트가 토큰을 가지고 있고, Redis에 토큰이 있다면 바로 프론트로 리다이렉트
-        if (token != null && redisTokenService.existsToken(token)) {
+        if (authToken != null && redisTokenService.existsToken(authToken)) {
             response.sendRedirect(successRedirect);
             return;
         }
 
         UserSession session = UserSession.of(String.valueOf(user.getUserId()), user.getName());
-        token = UUID.randomUUID().toString();
+        authToken = UUID.randomUUID().toString();
         try {
             String json = objectMapper.writeValueAsString(session);
             stringRedisTemplate.opsForValue()
-                .set("auth:token:" + token, json, Duration.ofDays(7));
+                .set("auth:token:" + authToken, json, Duration.ofDays(7));
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("세션 직렬화 실패", e);
+            throw new GeneralException(ErrorStatus.OAUTH2_SESSION_SERIALIZE_FAILED);
         }
 
-        Cookie cookie = createCookie(token);
+        Cookie cookie = createCookie(authToken);
         response.addCookie(cookie);
 
         response.sendRedirect(successRedirect);
     }
 
-    private String findToken(Cookie[] cookies) {
+    private String findAuthToken(Cookie[] cookies) {
         if (cookies != null) {
             for (Cookie c : cookies) {
                 if ("AUTH-TOKEN".equals(c.getName())) {
@@ -105,25 +107,26 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         return null;
     }
 
+    // 추후 회원가입 로직 추가
     private User findOrCreateUser(Authentication authentication) {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        String providerId = oAuth2User.getAttribute("accountId");
+        String accountId = oAuth2User.getAttribute("accountId");
         String email = oAuth2User.getAttribute("email");
         String name = oAuth2User.getAttribute("name");
 
-        User user = null;
-        if (name != null) {
-            user = userRepository.findUserByAccountIdAndStatus(providerId, Status.ACTIVE)
-                .orElse(null);
-        }
+        User user = userRepository.findUserByAccountIdAndStatus(accountId, Status.ACTIVE)
+            .orElse(null);
 
         if (user == null) {
+            AccountType accountType = getAccountType(authentication);
+
             user = User.builder()
-                .accountId(providerId)
-                .name(name != null ? name : "user")
+                .accountId(accountId)
+                .name(name)
                 .email(email)
-                .accountType(getAccountType(authentication))
+                .accountType(accountType)
                 .build();
+
             user = userRepository.save(user);
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -97,6 +97,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 return AccountType.KAKAO;
             } else if (registrationId.equals("naver")) {
                 return AccountType.NAVER;
+            } else if (registrationId.equals("google")) {
+                return AccountType.GOOGLE;
             }
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
@@ -1,12 +1,12 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.CustomOAuth2AuthenticationException;
 import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
@@ -31,11 +31,7 @@ public class CompositeOAuth2UserService implements
 
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = delegates.get(registrationId);
         if (delegate == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.PROVIDER_UNAVAILABLE.getCode(),
-                    OAuth2ErrorType.PROVIDER_UNAVAILABLE.getMessage(),
-                    OAuth2ErrorType.PROVIDER_UNAVAILABLE.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.PROVIDER_UNAVAILABLE);
         }
 
         return delegate.loadUser(req);

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -31,8 +32,9 @@ public class CompositeOAuth2UserService implements
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = delegates.get(registrationId);
         if (delegate == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("provider_unavailable", "지원하지 않는 로그인 방식입니다.",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.PROVIDER_UNAVAILABLE.getCode(),
+                    OAuth2ErrorType.PROVIDER_UNAVAILABLE.getMessage(),
+                    OAuth2ErrorType.PROVIDER_UNAVAILABLE.getUrl())
             );
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
@@ -31,8 +31,8 @@ public class CompositeOAuth2UserService implements
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = delegates.get(registrationId);
         if (delegate == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("unsupported_provider"),
-                "unsupported_provider: " + registrationId
+                new OAuth2Error("provider_unavailable", "지원하지 않는 로그인 방식입니다.",
+                    null)
             );
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/CompositeOAuth2UserService.java
@@ -16,6 +16,7 @@ public class CompositeOAuth2UserService implements
 
     private final KakaoOAuth2UserService kakaoOAuth2UserService;
     private final NaverOAuth2UserService naverOAuth2UserService;
+    private final GoogleOAuth2UserService googleOAuth2UserService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest req) throws OAuth2AuthenticationException {
@@ -23,14 +24,15 @@ public class CompositeOAuth2UserService implements
 
         Map<String, OAuth2UserService<OAuth2UserRequest, OAuth2User>> delegates = Map.of(
             "kakao", kakaoOAuth2UserService,
-            "naver", naverOAuth2UserService
+            "naver", naverOAuth2UserService,
+            "google", googleOAuth2UserService
         );
 
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = delegates.get(registrationId);
         if (delegate == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("지원하지 않는 로그인 방식입니다."),
-                "Unsupported OAuth2 provider: " + registrationId
+                new OAuth2Error("unsupported_provider"),
+                "unsupported_provider: " + registrationId
             );
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -33,15 +34,17 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         if (accountId == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("google_account_id_missing", "구글 로그인 중 필수 정보가 누락되었습니다.(accountId)",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING.getCode(),
+                    OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING.getMessage(),
+                    OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING.getUrl())
             );
         }
-
+        
         if (name == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("google_name_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(name)",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.GOOGLE_NAME_MISSING.getCode(),
+                    OAuth2ErrorType.GOOGLE_NAME_MISSING.getMessage(),
+                    OAuth2ErrorType.GOOGLE_NAME_MISSING.getUrl())
             );
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.CustomOAuth2AuthenticationException;
 import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -33,19 +33,12 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String email = (String) attributes.get("email");
 
         if (accountId == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING.getCode(),
-                    OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING.getMessage(),
-                    OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(
+                OAuth2ErrorType.GOOGLE_ACCOUNT_ID_MISSING);
         }
-        
+
         if (name == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.GOOGLE_NAME_MISSING.getCode(),
-                    OAuth2ErrorType.GOOGLE_NAME_MISSING.getMessage(),
-                    OAuth2ErrorType.GOOGLE_NAME_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.GOOGLE_NAME_MISSING);
         }
 
         Map<String, Object> customAttributes = new HashMap<>();

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
@@ -1,0 +1,43 @@
+package com.hotpack.krocs.global.security.oauth2.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String accountId = (String) attributes.get("sub");
+        String name = (String) attributes.get("name");
+        String email = (String) attributes.get("email");
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("accountId", accountId);
+        customAttributes.put("name", name);
+        customAttributes.put("email", email);
+
+        String userNameAttributeName = "accountId";
+
+        return new DefaultOAuth2User(
+            oAuth2User.getAuthorities(),
+            customAttributes,
+            userNameAttributeName
+        );
+    }
+
+}

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/GoogleOAuth2UserService.java
@@ -3,10 +3,12 @@ package com.hotpack.krocs.global.security.oauth2.service;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,9 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
 
+    @Value("${NAME_ATTRIBUTE_KEY}")
+    private String nameAttributeKey;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
@@ -26,17 +31,29 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String name = (String) attributes.get("name");
         String email = (String) attributes.get("email");
 
+        if (accountId == null) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("google_account_id_missing", "구글 로그인 중 필수 정보가 누락되었습니다.(accountId)",
+                    null)
+            );
+        }
+
+        if (name == null) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("google_name_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(name)",
+                    null)
+            );
+        }
+
         Map<String, Object> customAttributes = new HashMap<>();
         customAttributes.put("accountId", accountId);
         customAttributes.put("name", name);
         customAttributes.put("email", email);
 
-        String userNameAttributeName = "accountId";
-
         return new DefaultOAuth2User(
             oAuth2User.getAuthorities(),
             customAttributes,
-            userNameAttributeName
+            nameAttributeKey
         );
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
@@ -3,10 +3,12 @@ package com.hotpack.krocs.global.security.oauth2.service;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -17,11 +19,14 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
     private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
 
+    @Value("${NAME_ATTRIBUTE_KEY}")
+    private String nameAttributeKey;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
-
         Map<String, Object> attrs = oAuth2User.getAttributes();
+
         Object idObj = attrs.get("id");
         String accountId = null;
         if (idObj instanceof Number num) {
@@ -30,11 +35,22 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
             accountId = str;
         }
 
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attrs.get("kakao_account");
-        Map<String, Object> profile =
-            kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
-        String name = profile != null ? (String) profile.get("nickname") : null;
-        String email = profile != null ? (String) profile.get("email") : null;
+        if (accountId == null) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("kakao_account_id_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(accountId)",
+                    null)
+            );
+        }
+
+        Map<String, Object> profile = extractProfile(attrs);
+        String name = (String) profile.get("nickname");
+        String email = (String) profile.get("email");
+
+        if (name == null) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("kakao_name_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(name)", null)
+            );
+        }
 
         Map<String, Object> customAttributes = new HashMap<>();
         customAttributes.put("accountId", accountId);
@@ -44,7 +60,28 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         return new DefaultOAuth2User(
             oAuth2User.getAuthorities(),
             customAttributes,
-            "accountId"
+            nameAttributeKey
         );
+    }
+
+    private Map<String, Object> extractProfile(Map<String, Object> attribute) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+
+        if (kakaoAccount == null) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("kakao_kakao_account_missing",
+                    "카카로 로그인 중 필수 정보가 누락되었습니다.(kakao_account)", null)
+            );
+        }
+
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        if (profile == null) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("kakao_profile_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(profile)", null)
+            );
+        }
+
+        return profile;
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.CustomOAuth2AuthenticationException;
 import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -37,11 +37,7 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         }
 
         if (accountId == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING.getCode(),
-                    OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING.getMessage(),
-                    OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING);
         }
 
         Map<String, Object> profile = extractProfile(attrs);
@@ -49,11 +45,7 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         String email = (String) profile.get("email");
 
         if (name == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.KAKAO_NAME_MISSING.getCode(),
-                    OAuth2ErrorType.KAKAO_NAME_MISSING.getMessage(),
-                    OAuth2ErrorType.KAKAO_NAME_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.KAKAO_NAME_MISSING);
         }
 
         Map<String, Object> customAttributes = new HashMap<>();
@@ -72,21 +64,14 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
 
         if (kakaoAccount == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING.getCode(),
-                    OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING.getMessage(),
-                    OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(
+                OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING);
         }
 
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-        
+
         if (profile == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.KAKAO_PROFILE_MISSING.getCode(),
-                    OAuth2ErrorType.KAKAO_PROFILE_MISSING.getMessage(),
-                    OAuth2ErrorType.KAKAO_PROFILE_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.KAKAO_PROFILE_MISSING);
         }
 
         return profile;

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +38,9 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
         if (accountId == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("kakao_account_id_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(accountId)",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING.getCode(),
+                    OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING.getMessage(),
+                    OAuth2ErrorType.KAKAO_ACCOUNT_ID_MISSING.getUrl())
             );
         }
 
@@ -48,7 +50,9 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
         if (name == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("kakao_name_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(name)", null)
+                new OAuth2Error(OAuth2ErrorType.KAKAO_NAME_MISSING.getCode(),
+                    OAuth2ErrorType.KAKAO_NAME_MISSING.getMessage(),
+                    OAuth2ErrorType.KAKAO_NAME_MISSING.getUrl())
             );
         }
 
@@ -69,16 +73,19 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
         if (kakaoAccount == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("kakao_kakao_account_missing",
-                    "카카로 로그인 중 필수 정보가 누락되었습니다.(kakao_account)", null)
+                new OAuth2Error(OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING.getCode(),
+                    OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING.getMessage(),
+                    OAuth2ErrorType.KAKAO_KAKAO_ACCOUNT_MISSING.getUrl())
             );
         }
 
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-
+        
         if (profile == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("kakao_profile_missing", "카카오 로그인 중 필수 정보가 누락되었습니다.(profile)", null)
+                new OAuth2Error(OAuth2ErrorType.KAKAO_PROFILE_MISSING.getCode(),
+                    OAuth2ErrorType.KAKAO_PROFILE_MISSING.getMessage(),
+                    OAuth2ErrorType.KAKAO_PROFILE_MISSING.getUrl())
             );
         }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/KakaoOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -33,13 +34,16 @@ public class KakaoOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         Map<String, Object> profile =
             kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
         String name = profile != null ? (String) profile.get("nickname") : null;
+        String email = profile != null ? (String) profile.get("email") : null;
+
+        Map<String, Object> customAttributes = new HashMap<>();
+        customAttributes.put("accountId", accountId);
+        customAttributes.put("name", name);
+        customAttributes.put("email", email);
 
         return new DefaultOAuth2User(
             oAuth2User.getAuthorities(),
-            Map.of(
-                "accountId", accountId,
-                "name", name
-            ),
+            customAttributes,
             "accountId"
         );
     }

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
@@ -3,10 +3,13 @@ package com.hotpack.krocs.global.security.oauth2.service;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
@@ -16,25 +19,39 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
     private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
 
+    @Value("${NAME_ATTRIBUTE_KEY}")
+    private String nameAttributeKey;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oauth2User = delegate.loadUser(userRequest);
 
         Map<String, Object> attributes = oauth2User.getAttributes();
+
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
-            throw new OAuth2AuthenticationException("Naver response attribute is missing");
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("naver_response_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(response)",
+                    null)
+            );
         }
 
         String accountId = (String) response.get("id");
         String name = (String) response.get("name");
         String email = (String) response.get("email");
-        
+
         if (accountId == null) {
-            throw new OAuth2AuthenticationException("Naver accountId is missing");
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("naver_account_id_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(accountId)",
+                    null)
+            );
         }
+
         if (name == null) {
-            name = (String) response.get("naverUser");
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error("naver_name_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(name)",
+                    null)
+            );
         }
 
         Map<String, Object> customAttributes = new HashMap<>();
@@ -42,12 +59,10 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         customAttributes.put("name", name);
         customAttributes.put("email", email);
 
-        String userNameAttributeName = "accountId";
-
-        return new org.springframework.security.oauth2.core.user.DefaultOAuth2User(
+        return new DefaultOAuth2User(
             oauth2User.getAuthorities(),
             customAttributes,
-            userNameAttributeName
+            nameAttributeKey
         );
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.CustomOAuth2AuthenticationException;
 import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -31,11 +31,7 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.NAVER_RESPONSE_MISSING.getCode(),
-                    OAuth2ErrorType.NAVER_RESPONSE_MISSING.getMessage(),
-                    OAuth2ErrorType.NAVER_RESPONSE_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.NAVER_RESPONSE_MISSING);
         }
 
         String accountId = (String) response.get("id");
@@ -43,19 +39,11 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         String email = (String) response.get("email");
 
         if (accountId == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING.getCode(),
-                    OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING.getMessage(),
-                    OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING);
         }
 
         if (name == null) {
-            throw new OAuth2AuthenticationException(
-                new OAuth2Error(OAuth2ErrorType.NAVER_NAME_MISSING.getCode(),
-                    OAuth2ErrorType.NAVER_NAME_MISSING.getMessage(),
-                    OAuth2ErrorType.NAVER_NAME_MISSING.getUrl())
-            );
+            throw new CustomOAuth2AuthenticationException(OAuth2ErrorType.NAVER_NAME_MISSING);
         }
 
         Map<String, Object> customAttributes = new HashMap<>();

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
@@ -28,6 +28,8 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
         String accountId = (String) response.get("id");
         String name = (String) response.get("name");
+        String email = (String) response.get("email");
+        
         if (accountId == null) {
             throw new OAuth2AuthenticationException("Naver accountId is missing");
         }
@@ -38,6 +40,7 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         Map<String, Object> customAttributes = new HashMap<>();
         customAttributes.put("accountId", accountId);
         customAttributes.put("name", name);
+        customAttributes.put("email", email);
 
         String userNameAttributeName = "accountId";
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/oauth2/service/NaverOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.global.security.oauth2.service;
 
+import com.hotpack.krocs.global.security.oauth2.exception.OAuth2ErrorType;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +32,9 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         if (response == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("naver_response_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(response)",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.NAVER_RESPONSE_MISSING.getCode(),
+                    OAuth2ErrorType.NAVER_RESPONSE_MISSING.getMessage(),
+                    OAuth2ErrorType.NAVER_RESPONSE_MISSING.getUrl())
             );
         }
 
@@ -42,15 +44,17 @@ public class NaverOAuth2UserService implements OAuth2UserService<OAuth2UserReque
 
         if (accountId == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("naver_account_id_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(accountId)",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING.getCode(),
+                    OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING.getMessage(),
+                    OAuth2ErrorType.NAVER_ACCOUNT_ID_MISSING.getUrl())
             );
         }
 
         if (name == null) {
             throw new OAuth2AuthenticationException(
-                new OAuth2Error("naver_name_missing", "네이버 로그인 중 필수 정보가 누락되었습니다.(name)",
-                    null)
+                new OAuth2Error(OAuth2ErrorType.NAVER_NAME_MISSING.getCode(),
+                    OAuth2ErrorType.NAVER_NAME_MISSING.getMessage(),
+                    OAuth2ErrorType.NAVER_NAME_MISSING.getUrl())
             );
         }
 

--- a/backend/src/main/resources/messages_ko.properties
+++ b/backend/src/main/resources/messages_ko.properties
@@ -1,3 +1,32 @@
 # === Goal Validation ===
-
+goal.title.notBlank=목표 제목은 필수입니다.
+goal.title.size=목표 제목은 {max}자를 초과할 수 없습니다.
+goal.date.invalidRange=유효하지 않은 목표 기간입니다.
+goal.date.startRequired=목표 시작일은 필수입니다.
+goal.date.endRequired=목표 종료일은 필수입니다.
 # === SubGoal Validation ===
+subgoal.list.notEmpty=하위 일정은 1개 이상이어야 합니다.
+subgoal.title.notBlank=소목표 제목은 필수입니다.
+subgoal.title.size=소목표 제목은 {max}자를 초과할 수 없습니다.
+# === Plan Validation ===
+plan.title.notBlank=일정 제목은 필수입니다.
+plan.title.size=일정 제목은 {max}자를 초과할 수 없습니다.
+plan.priority.notNull=일정 우선순위는 필수입니다.
+plan.startDate.notNull=일정 시작일은 필수입니다.
+plan.endDate.notNull=일정 종료일은 필수입니다.
+plan.duration.min=일정 기간은 최소 {value}일 이상이어야 합니다.
+# === SubPlan Validation ===
+subplan.list.notEmpty=하위 일정은 1개 이상이어야 합니다.
+subplan.title.notBlank=하위 일정 제목은 필수입니다.
+subplan.title.size=하위 일정 제목은 {max}자를 초과할 수 없습니다.
+# === Template Validation ===
+template.title.notBlank=템플릿 제목은 필수입니다.
+template.title.size=템플릿 제목은 {max}자를 초과할 수 없습니다.
+template.priority.notNull=템플릿 우선순위를 선택해야 합니다.
+template.duration.notNull=템플릿 소요 시간을 입력해야 합니다.
+template.repeat.notNull=템플릿 반복 여부를 선택해야 합니다.
+template.duration.positive=템플릿 기간은 최소 1일 이상 입력해야 합니다.
+# === SubTemplate Validation ===
+subtemplate.title.notBlank=소템플릿 제목은 필수입니다.
+subtemplate.title.size=소템플릿 제목은 {max}자를 초과할 수 없습니다.
+subtemplate.list.notEmpty=소템플릿은 최소 1개 이상 입력해야 합니다.

--- a/backend/src/main/resources/messages_ko.properties
+++ b/backend/src/main/resources/messages_ko.properties
@@ -1,37 +1,3 @@
 # === Goal Validation ===
-goal.title.notBlank=목표 제목은 필수입니다.
-goal.title.size=목표 제목은 {max}자를 초과할 수 없습니다.
-goal.date.invalidRange=유효하지 않은 목표 기간입니다.
-goal.date.startRequired=목표 시작일은 필수입니다.
-goal.date.endRequired=목표 종료일은 필수입니다.
 
 # === SubGoal Validation ===
-subgoal.list.notEmpty=하위 일정은 1개 이상이어야 합니다.
-subgoal.title.notBlank=소목표 제목은 필수입니다.
-subgoal.title.size=소목표 제목은 {max}자를 초과할 수 없습니다.
-
-# === Plan Validation ===
-plan.title.notBlank=일정 제목은 필수입니다.
-plan.title.size=일정 제목은 {max}자를 초과할 수 없습니다.
-plan.priority.notNull=일정 우선순위는 필수입니다.
-plan.startDate.notNull=일정 시작일은 필수입니다.
-plan.endDate.notNull=일정 종료일은 필수입니다.
-plan.duration.min=일정 기간은 최소 {value}일 이상이어야 합니다.
-
-# === SubPlan Validation ===
-subplan.list.notEmpty=하위 일정은 1개 이상이어야 합니다.
-subplan.title.notBlank=하위 일정 제목은 필수입니다.
-subplan.title.size=하위 일정 제목은 {max}자를 초과할 수 없습니다.
-
-# === Template Validation ===
-template.title.notBlank=템플릿 제목은 필수입니다.
-template.title.size=템플릿 제목은 {max}자를 초과할 수 없습니다.
-template.priority.notNull=템플릿 우선순위를 선택해야 합니다.
-template.duration.notNull=템플릿 소요 시간을 입력해야 합니다.
-template.repeat.notNull=템플릿 반복 여부를 선택해야 합니다.
-template.duration.positive= 템플릿 기간은 최소 1일 이상 입력해야 합니다.
-
-# === SubTemplate Validation ===
-subtemplate.title.notBlank=소템플릿 제목은 필수입니다.
-subtemplate.title.size=소템플릿 제목은 {max}자를 초과할 수 없습니다.
-subtemplate.list.notEmpty=소템플릿은 최소 1개 이상 입력해야 합니다.

--- a/backend/src/test/java/com/hotpack/krocs/AuthE2ETest.java
+++ b/backend/src/test/java/com/hotpack/krocs/AuthE2ETest.java
@@ -35,7 +35,7 @@ class AuthE2ETest {
 
     @Test
     void 인증_성공시_me_조회() throws Exception {
-        mockMvc.perform(get("/auth/me").header("Authorization", "Bearer " + TEST_TOKEN))
+        mockMvc.perform(get("/api/v1//auth/me").header("Authorization", "Bearer " + TEST_TOKEN))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.isSuccess").value(true))
             .andExpect(jsonPath("$.result.userId").value("u-123"));
@@ -43,7 +43,7 @@ class AuthE2ETest {
 
     @Test
     void 토큰_없으면_401() throws Exception {
-        mockMvc.perform(get("/auth/me"))
+        mockMvc.perform(get("/api/v1//auth/me"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("GLOBAL401"));
     }

--- a/backend/src/test/java/com/hotpack/krocs/AuthE2ETest.java
+++ b/backend/src/test/java/com/hotpack/krocs/AuthE2ETest.java
@@ -35,7 +35,7 @@ class AuthE2ETest {
 
     @Test
     void 인증_성공시_me_조회() throws Exception {
-        mockMvc.perform(get("/api/v1//auth/me").header("Authorization", "Bearer " + TEST_TOKEN))
+        mockMvc.perform(get("/api/v1/auth/me").header("Authorization", "Bearer " + TEST_TOKEN))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.isSuccess").value(true))
             .andExpect(jsonPath("$.result.userId").value("u-123"));
@@ -43,7 +43,7 @@ class AuthE2ETest {
 
     @Test
     void 토큰_없으면_401() throws Exception {
-        mockMvc.perform(get("/api/v1//auth/me"))
+        mockMvc.perform(get("/api/v1/auth/me"))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.code").value("GLOBAL401"));
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #119 

## 🚀 작업 내용
- [x] `AuthController` url 수정
- [x] `application.properties` 구글 속성 추가
- [x] `GoogleOAuth2UserService` 구현
- [x] `CompositeOAuth2UserService`에 `GoogleOAuth2UserService` 추가
- [x] `LoginSuccessHandler`에 Google 로그인 추가
- [x] 로그인 예외상황 정리 및 에러 핸들링 구현

## 🔍 리뷰 요청 사항 및 공유자료
{provider}OAuth2UserService의 validate 메서드 적용 여부에 대해 의견 남겨주시면 감사하겠습니다!

### OAuth2에서는 어떤 예외를 발생시키나요?
- `{provider}OAuth2UserService`에서는 `OAuth2AuthenticationException()` 예외 발생.
    - 이유: 위의 오류를 날려야 SuccessHandler가 작동하지 않고 faliureHanlder로 분기가 넘어가게됩니다.
- `OAuth2Error`를 사용하는 이유
  - 위의 에러 형식으로 날리면 프론트에 `/login?error=missing_profile` 쿼리스트링 형식으로 에러가 가게됩니다. 이를 가지고 프론트는 적절한 화면을 출력할 수 있습니다.

- `SuccessHandler`에서는 `GeneralException()` 예외 발생.
  - 이유: 이미 OAuth2인증이 완료되었으므로 여기선 세션 직렬화 오류같은 비지니스로직의 예외이기 때문입니다.


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
20분
