### PR TITLE
[refactor] Plan에서 subgoal, goal 삭제 / planCategory 요소 추가

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/PlanController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/PlanController.java
@@ -36,12 +36,11 @@ public class PlanController {
     @PostMapping
     public ApiResponse<PlanResponseDTO> createPlan(
         @Valid @RequestBody PlanCreateRequestDTO requestDTO,
-        @Login UserSession user,
-        @RequestParam(value = "sub_goal_id", required = false) Long subGoalId
+        @Login UserSession user
     ) {
         try {
             Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
-            PlanResponseDTO responseDTO = planService.createPlan(requestDTO, userId, subGoalId);
+            PlanResponseDTO responseDTO = planService.createPlan(requestDTO, userId);
             return ApiResponse.success(responseDTO);
         } catch (PlanException e) {
             throw e;
@@ -92,13 +91,11 @@ public class PlanController {
     public ApiResponse<PlanResponseDTO> updatePlanById(
         @PathVariable @Positive(message = "{common.id.positive}") Long planId,
         @Valid @RequestBody PlanUpdateRequestDTO request,
-        @Login UserSession user,
-        @RequestParam(value = "sub_goal_id", required = false) @Positive(message = "{common.id.positive}") Long subGoalId) {
+        @Login UserSession user) {
 
         try {
             Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
-            PlanResponseDTO responseDTO = planService.updatePlanById(planId, subGoalId, request,
-                userId);
+            PlanResponseDTO responseDTO = planService.updatePlanById(planId, request, userId);
 
             return ApiResponse.success(responseDTO);
         } catch (PlanException e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/converter/PlanConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/converter/PlanConverter.java
@@ -1,7 +1,5 @@
 package com.hotpack.krocs.domain.plans.converter;
 
-import com.hotpack.krocs.domain.goals.domain.Goal;
-import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.plans.domain.Plan;
 import com.hotpack.krocs.domain.plans.dto.request.PlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.request.PlanUpdateRequestDTO;
@@ -20,7 +18,7 @@ public class PlanConverter {
 
     private final SubPlanConverter subPlanConverter;
 
-    public Plan toEntity(PlanCreateRequestDTO requestDTO, Goal goal, SubGoal subGoal) {
+    public Plan toEntity(PlanCreateRequestDTO requestDTO) {
         LocalDateTime startDateTime = requestDTO.getStartDateTime();
         LocalDateTime endDateTime = requestDTO.getEndDateTime();
 
@@ -35,8 +33,6 @@ public class PlanConverter {
         }
 
         return Plan.builder()
-            .goal(goal)
-            .subGoal(subGoal)
             .title(requestDTO.getTitle())
             .planCategory(requestDTO.getPlanCategory())
             .color(requestDTO.getColor())
@@ -47,7 +43,7 @@ public class PlanConverter {
             .build();
     }
 
-    public Plan toEntity(PlanCreateRequestDTO requestDTO, Goal goal, SubGoal subGoal, User user) {
+    public Plan toEntity(PlanCreateRequestDTO requestDTO, User user) {
         LocalDateTime startDateTime = requestDTO.getStartDateTime();
         LocalDateTime endDateTime = requestDTO.getEndDateTime();
 
@@ -63,8 +59,6 @@ public class PlanConverter {
 
         return Plan.builder()
             .user(user)
-            .goal(goal)
-            .subGoal(subGoal)
             .planCategory(requestDTO.getPlanCategory())
             .color(requestDTO.getColor())
             .title(requestDTO.getTitle())
@@ -95,14 +89,6 @@ public class PlanConverter {
             .completedAt(plan.getCompletedAt())
             .createdAt(plan.getCreatedAt())
             .updatedAt(plan.getUpdatedAt());
-
-        if (plan.getGoal() != null) {
-            builder.goalId(plan.getGoal().getGoalId());
-        }
-
-        if (plan.getSubGoal() != null) {
-            builder.subGoalId(plan.getSubGoal().getSubGoalId());
-        }
 
         return builder.build();
     }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/domain/Plan.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/domain/Plan.java
@@ -31,8 +31,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "plans", indexes = {
     @Index(name = "idx_plans_user_id", columnList = "user_id"),
-    @Index(name = "idx_plans_goal_id", columnList = "goal_id"),
-    @Index(name = "idx_plans_sub_goal_id", columnList = "sub_goal_id")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -48,14 +46,6 @@ public class Plan extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "goal_id")
-    private Goal goal;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sub_goal_id")
-    private SubGoal subGoal;
 
     @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<SubPlan> subPlans;
@@ -103,7 +93,7 @@ public class Plan extends BaseTimeEntity {
     @Column(nullable = false)
     private Status status = Status.ACTIVE;
 
-    public void updateFrom(PlanUpdateRequestDTO request, Goal goal, SubGoal subGoal) {
+    public void updateFrom(PlanUpdateRequestDTO request) {
         if (request.getTitle() != null) {
             this.title = request.getTitle();
         }
@@ -135,14 +125,6 @@ public class Plan extends BaseTimeEntity {
             } else {
                 this.completedAt = null;
             }
-        }
-
-        if (goal != null) {
-            this.goal = goal;
-        }
-
-        if (subGoal != null) {
-            this.subGoal = subGoal;
         }
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/domain/PlanCategory.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/domain/PlanCategory.java
@@ -1,7 +1,15 @@
 package com.hotpack.krocs.domain.plans.domain;
 
 public enum PlanCategory {
-    WORK,  // 업무
-    STUDY,  // 학습
-    ETC   // 카테고리 없음, DEFAULT
+    WORK,      // 업무
+    STUDY,     // 학습
+    WORKOUT,   // 운동
+    REST,      // 휴식
+    HEALTH,    // 건강
+    IMPORTANT, // 중요
+    ENERGY,    // 에너지
+    MUSIC,     // 음악
+    PHOTO,     // 사진
+    GAME,      // 게임
+    ETC        // 카테고리 없음, DEFAULT
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/PlanResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/PlanResponseDTO.java
@@ -18,10 +18,6 @@ public class PlanResponseDTO {
 
     @JsonProperty("plan_id")
     private Long planId;
-    @JsonProperty("goal_id")
-    private Long goalId;
-    @JsonProperty("sub_goal_id")
-    private Long subGoalId;
 
     @JsonProperty("sub_plans")
     private List<SubPlanResponseDTO> subPlans;

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanResponseDTO.java
@@ -19,7 +19,6 @@ public class SubPlanResponseDTO {
     @JsonProperty("is_completed")
     private final Boolean isCompleted;
 
-
     @Schema(
         description = "완료 일시",
         pattern = "yyyy-MM-dd'T'HH:mm:ss",

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanUpdateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/dto/response/SubPlanUpdateResponseDTO.java
@@ -11,21 +11,17 @@ import lombok.Getter;
 @Getter
 public class SubPlanUpdateResponseDTO {
 
-    @Schema(
-        description = "완료 일시",
-        pattern = "yyyy-MM-dd'T'HH:mm:ss",
-        example = "2025-08-03T15:05:12"
-    )
-    @JsonProperty("completed_at")
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private final LocalDateTime completedAt;
     @JsonProperty("sub_plan_id")
     private Long subPlanId;
+
     @JsonProperty("plan_id")
     private Long planId;
+
     private String title;
+
     @JsonProperty("is_completed")
     private Boolean isCompleted;
+
     @Schema(
         description = "생성 일시",
         pattern = "yyyy-MM-dd'T'HH:mm:ss",
@@ -43,4 +39,13 @@ public class SubPlanUpdateResponseDTO {
     @JsonProperty("updated_at")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime updatedAt;
+
+    @Schema(
+        description = "완료 일시",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss",
+        example = "2025-08-03T15:05:12"
+    )
+    @JsonProperty("completed_at")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime completedAt;
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/PlanExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/PlanExceptionType.java
@@ -27,9 +27,6 @@ public enum PlanExceptionType implements BaseCode {
     PLAN_START_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN400", "일정 시작시간을 입력해주세요."),
     PLAN_END_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN400", "일정 종료시간을 입력해주세요."),
     PLAN_INVALID_ENERGY(HttpStatus.BAD_REQUEST, "PLAN400", "유효하지 않은 에너지 값입니다."),
-    PLAN_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404", "목표를 찾을 수 없습니다."),
-    PLAN_SUB_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404", "서브목표를 찾을 수 없습니다."),
-    PLAN_INVALID_GOAL_ID(HttpStatus.NOT_FOUND, "PLAN404", "유효하지 않은 목표 ID입니다."),
     PLAN_SUB_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404", "세부일정을 찾을 수 없습니다."),
     PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "PLAN400", "계획 ID가 null 입니다.");
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/PlanService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/PlanService.java
@@ -8,13 +8,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public interface PlanService {
-    PlanResponseDTO createPlan(PlanCreateRequestDTO requestDTO, Long userId, Long goalId);
+    PlanResponseDTO createPlan(PlanCreateRequestDTO requestDTO, Long userId);
 
     PlanListResponseDTO getPlans(LocalDate date, Long userId);
 
     PlanResponseDTO getPlanById(Long planId, Long userId);
 
-    PlanResponseDTO updatePlanById(Long planId, Long subGoalId, PlanUpdateRequestDTO request, Long userId);
+    PlanResponseDTO updatePlanById(Long planId, PlanUpdateRequestDTO request, Long userId);
 
     void deletePlan(Long planId, Long userId);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/PlanServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/PlanServiceImpl.java
@@ -36,34 +36,18 @@ public class PlanServiceImpl implements PlanService {
 
     @Override
     @Transactional
-    public PlanResponseDTO createPlan(PlanCreateRequestDTO requestDTO, Long userId,
-        Long subGoalId) {
+    public PlanResponseDTO createPlan(PlanCreateRequestDTO requestDTO, Long userId) {
         try {
-            planValidator.validatePlanCreation(requestDTO, subGoalId);
-
-            SubGoal subGoal = null;
-            Goal goal = null;
-
-            if (subGoalId != null) {
-                subGoal = subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId);
-                if (subGoal == null) {
-                    throw new PlanException(PlanExceptionType.PLAN_SUB_GOAL_NOT_FOUND);
-                }
-
-                goal = subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId);
-                if (goal == null) {
-                    throw new PlanException(PlanExceptionType.PLAN_GOAL_NOT_FOUND);
-                }
-            }
+            planValidator.validatePlanCreation(requestDTO);
 
             Plan plan;
             if (userId != null) {
                 User userRef = User.builder()
                     .userId(userId)
                     .build();
-                plan = planConverter.toEntity(requestDTO, goal, subGoal, userRef);
+                plan = planConverter.toEntity(requestDTO, userRef);
             } else {
-                plan = planConverter.toEntity(requestDTO, goal, subGoal);
+                plan = planConverter.toEntity(requestDTO);
             }
             Plan savedPlan = planRepositoryFacade.savePlan(plan);
 
@@ -120,7 +104,7 @@ public class PlanServiceImpl implements PlanService {
 
     @Override
     @Transactional
-    public PlanResponseDTO updatePlanById(Long planId, Long subGoalId, PlanUpdateRequestDTO request,
+    public PlanResponseDTO updatePlanById(Long planId, PlanUpdateRequestDTO request,
         Long userId) {
         try {
             planValidator.validateUpdatePlan(planId);
@@ -128,16 +112,6 @@ public class PlanServiceImpl implements PlanService {
             Plan plan = planRepositoryFacade.findActivePlanById(planId);
             if (plan == null) {
                 throw new PlanException(PlanExceptionType.PLAN_NOT_FOUND);
-            }
-
-            SubGoal subGoal = plan.getSubGoal();
-            Goal goal = plan.getGoal();
-            if (subGoalId != null) {
-                subGoal = subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId);
-                if (subGoal == null) {
-                    throw new PlanException(PlanExceptionType.PLAN_SUB_GOAL_NOT_FOUND);
-                }
-                goal = subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId);
             }
 
             if (request.getTitle() != null) {
@@ -178,7 +152,7 @@ public class PlanServiceImpl implements PlanService {
             PlanUpdateRequestDTO updatePlanRequestDTO = planConverter.toUpdatePlanRequestDTO(
                 request, allDay, startDateTime, endDateTime);
 
-            plan.updateFrom(updatePlanRequestDTO, goal, subGoal);
+            plan.updateFrom(updatePlanRequestDTO);
 
             return planConverter.toEntity(plan);
         } catch (PlanException e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/validator/PlanValidator.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/validator/PlanValidator.java
@@ -17,7 +17,7 @@ import org.springframework.util.StringUtils;
 @Transactional(readOnly = true)
 public class PlanValidator {
 
-    public void validatePlanCreation(PlanCreateRequestDTO requestDTO, Long subGoalId) {
+    public void validatePlanCreation(PlanCreateRequestDTO requestDTO) {
         Boolean allDay = requestDTO.getAllDay();
         if (allDay == null) {
             allDay = false;
@@ -25,7 +25,6 @@ public class PlanValidator {
 
         validateTitle(requestDTO.getTitle());
         validatePlanCategory(requestDTO.getPlanCategory());
-        validateSubGoalIdParameter(subGoalId);
         validateAllDayDateTime(allDay, requestDTO.getStartDateTime(), requestDTO.getEndDateTime());
     }
 
@@ -44,13 +43,6 @@ public class PlanValidator {
     private void validatePlanIdParameter(Long planId) {
         if (planId == null || planId <= 0) {
             throw new PlanException(PlanExceptionType.PLAN_INVALID_PLAN_ID);
-        }
-    }
-
-    public void validateSubGoalIdParameter(Long subGoalId) {
-        if (subGoalId == null) return;
-        if (subGoalId <= 0) {
-            throw new PlanException(PlanExceptionType.PLAN_INVALID_GOAL_ID);
         }
     }
 

--- a/backend/src/main/resources/db/changelog/changes/006-drop-plans-columns.yaml
+++ b/backend/src/main/resources/db/changelog/changes/006-drop-plans-columns.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 006-drop-plan-goal-id-column
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: plans
+            columnName: goal_id
+      changes:
+        - dropColumn:
+            tableName: plans
+            columnName: goal_id
+
+  - changeSet:
+      id: 006-drop-plan-sub-goal-id-column
+      author: system
+      preConditions:
+        - onFail: MARK_RAN
+        - columnExists:
+            tableName: plans
+            columnName: sub_goal_id
+      changes:
+        - dropColumn:
+            tableName: plans
+            columnName: sub_goal_id

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/converter/PlanConverterTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/converter/PlanConverterTest.java
@@ -65,8 +65,6 @@ public class PlanConverterTest {
 
         validPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .title("테스트 일정")
             .planCategory(PlanCategory.STUDY)
             .color(Color.BLUE)
@@ -83,12 +81,10 @@ public class PlanConverterTest {
     @DisplayName("RequestDTO를 Plan 엔티티로 변환")
     void toEntity_Success() {
         // when
-        Plan result = planConverter.toEntity(validRequestDTO, validGoal, validSubGoal);
+        Plan result = planConverter.toEntity(validRequestDTO);
 
         // then
         assertThat(result.getTitle()).isEqualTo("테스트 일정");
-        assertThat(result.getGoal()).isEqualTo(validGoal);
-        assertThat(result.getSubGoal()).isEqualTo(validSubGoal);
         assertThat(result.getPlanCategory()).isEqualTo(PlanCategory.STUDY);
         assertThat(result.getColor()).isEqualTo(Color.BLUE);
         assertThat(result.getStartDateTime()).isEqualTo(LocalDateTime.of(2025, 8, 1, 9, 0));
@@ -107,7 +103,7 @@ public class PlanConverterTest {
             .build();
 
         // when
-        Plan result = planConverter.toEntity(allDayRequest, validGoal, validSubGoal);
+        Plan result = planConverter.toEntity(allDayRequest);
 
         // then
         assertThat(result.getAllDay()).isTrue();
@@ -127,7 +123,7 @@ public class PlanConverterTest {
             .build();
 
         // when
-        Plan result = planConverter.toEntity(request, validGoal, validSubGoal);
+        Plan result = planConverter.toEntity(request);
 
         // then
         assertThat(result.getAllDay()).isFalse();
@@ -149,7 +145,7 @@ public class PlanConverterTest {
             .build();
 
         // when
-        Plan result = planConverter.toEntity(request, validGoal, validSubGoal);
+        Plan result = planConverter.toEntity(request);
 
         // then
         assertThat(result.getAllDay()).isNull();
@@ -171,7 +167,7 @@ public class PlanConverterTest {
             .build();
 
         // when
-        Plan result = planConverter.toEntity(request, validGoal, validSubGoal);
+        Plan result = planConverter.toEntity(request);
 
         // then
         assertThat(result.getAllDay()).isTrue();
@@ -179,49 +175,12 @@ public class PlanConverterTest {
         assertThat(result.getEndDateTime()).isEqualTo(LocalDateTime.of(2025, 8, 1, 23, 59, 59));
     }
 
-    @Test
-    @DisplayName("Goal과 SubGoal이 모두 null인 경우")
-    void toEntity_Goal_SubGoal_Both_Null() {
-        // when
-        Plan result = planConverter.toEntity(validRequestDTO, null, null);
-
-        // then
-        assertThat(result.getGoal()).isNull();
-        assertThat(result.getSubGoal()).isNull();
-        assertThat(result.getTitle()).isEqualTo("테스트 일정");
-        assertThat(result.getIsCompleted()).isFalse();
-    }
-
-    @Test
-    @DisplayName("Goal만 null인 경우")
-    void toEntity_Goal_Null() {
-        // when
-        Plan result = planConverter.toEntity(validRequestDTO, null, validSubGoal);
-
-        // then
-        assertThat(result.getGoal()).isNull();
-        assertThat(result.getSubGoal()).isEqualTo(validSubGoal);
-        assertThat(result.getTitle()).isEqualTo("테스트 일정");
-    }
-
-    @Test
-    @DisplayName("SubGoal만 null인 경우")
-    void toEntity_SubGoal_Null() {
-        // when
-        Plan result = planConverter.toEntity(validRequestDTO, validGoal, null);
-
-        // then
-        assertThat(result.getGoal()).isEqualTo(validGoal);
-        assertThat(result.getSubGoal()).isNull();
-        assertThat(result.getTitle()).isEqualTo("테스트 일정");
-    }
 
     @Test
     @DisplayName("RequestDTO가 null인 경우")
     void toEntity_RequestDTO_Null() {
         // when & then
-        assertThatThrownBy(() -> planConverter.toEntity(null, validGoal, validSubGoal))
-            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> planConverter.toEntity((PlanCreateRequestDTO) null)).isInstanceOf(NullPointerException.class);
     }
 
     // 2. toEntity from Plan
@@ -234,11 +193,9 @@ public class PlanConverterTest {
 
         // then
         assertThat(result.getPlanId()).isEqualTo(1L);
-        assertThat(result.getGoalId()).isEqualTo(1L);
         assertThat(result.getTitle()).isEqualTo("테스트 일정");
         assertThat(result.getPlanCategory()).isEqualTo(PlanCategory.STUDY);
         assertThat(result.getColor()).isEqualTo(Color.BLUE);
-        assertThat(result.getSubGoalId()).isEqualTo(1L);
         assertThat(result.getStartDateTime()).isEqualTo(LocalDateTime.of(2025, 8, 1, 9, 0));
         assertThat(result.getEndDateTime()).isEqualTo(LocalDateTime.of(2025, 8, 1, 10, 0));
         assertThat(result.getAllDay()).isFalse();
@@ -249,59 +206,10 @@ public class PlanConverterTest {
     @DisplayName("Plan 객체가 null인 경우")
     void toCreateResponseDTO_PlanNull() {
         // when & then
-        assertThatThrownBy(() -> planConverter.toEntity(null))
+        assertThatThrownBy(() -> planConverter.toEntity((Plan) null))
             .isInstanceOf(NullPointerException.class);
     }
 
-    @Test
-    @DisplayName("Plan의 Goal이 null인 경우")
-    void toResponseDTO_Plan_Goal_Null() {
-        // given
-        Plan planWithNullGoal = Plan.builder()
-            .planId(1L)
-            .goal(null)
-            .subGoal(validSubGoal)
-            .title("Goal 없는 일정")
-            .planCategory(PlanCategory.ETC)
-            .color(Color.GREEN)
-            .allDay(false)
-            .isCompleted(false)
-            .build();
-
-        // when
-        PlanResponseDTO result = planConverter.toEntity(planWithNullGoal);
-
-        // then
-        assertThat(result.getPlanId()).isEqualTo(1L);
-        assertThat(result.getGoalId()).isNull();
-        assertThat(result.getSubGoalId()).isEqualTo(1L);
-        assertThat(result.getTitle()).isEqualTo("Goal 없는 일정");
-    }
-
-    @Test
-    @DisplayName("Plan의 SubGoal이 null인 경우")
-    void toResponseDTO_Plan_SubGoal_Null() {
-        // given
-        Plan planWithNullSubGoal = Plan.builder()
-            .planId(1L)
-            .goal(validGoal)
-            .subGoal(null)
-            .title("SubGoal 없는 일정")
-            .planCategory(PlanCategory.ETC)
-            .color(Color.GREEN)
-            .allDay(false)
-            .isCompleted(false)
-            .build();
-
-        // when
-        PlanResponseDTO result = planConverter.toEntity(planWithNullSubGoal);
-
-        // then
-        assertThat(result.getPlanId()).isEqualTo(1L);
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getSubGoalId()).isNull();
-        assertThat(result.getTitle()).isEqualTo("SubGoal 없는 일정");
-    }
 
     @Test
     @DisplayName("Plan의 SubPlans가 null인 경우")
@@ -309,8 +217,6 @@ public class PlanConverterTest {
         // given
         Plan planWithNullSubPlans = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .subPlans(null)
             .title("SubPlans null인 일정")
             .allDay(false)
@@ -331,8 +237,6 @@ public class PlanConverterTest {
         // given
         Plan planWithEmptySubPlans = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .subPlans(List.of())
             .title("SubPlans 빈 리스트인 일정")
             .planCategory(PlanCategory.ETC)
@@ -356,8 +260,6 @@ public class PlanConverterTest {
         LocalDateTime completedTime = LocalDateTime.of(2025, 8, 1, 15, 0);
         Plan completedPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .title("완료된 일정")
             .planCategory(PlanCategory.ETC)
             .color(Color.GREEN)
@@ -385,8 +287,6 @@ public class PlanConverterTest {
             .title("일정 1")
             .planCategory(PlanCategory.ETC)
             .color(Color.GREEN)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .allDay(false)
             .isCompleted(false)
             .build();
@@ -396,8 +296,6 @@ public class PlanConverterTest {
             .title("일정 2")
             .planCategory(PlanCategory.ETC)
             .color(Color.GREEN)
-            .goal(null)
-            .subGoal(null)
             .allDay(true)
             .isCompleted(true)
             .build();
@@ -411,11 +309,9 @@ public class PlanConverterTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getPlanId()).isEqualTo(1L);
         assertThat(result.get(0).getTitle()).isEqualTo("일정 1");
-        assertThat(result.get(0).getGoalId()).isEqualTo(1L);
 
         assertThat(result.get(1).getPlanId()).isEqualTo(2L);
         assertThat(result.get(1).getTitle()).isEqualTo("일정 2");
-        assertThat(result.get(1).getGoalId()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/service/PlanServiceTest.java
@@ -60,8 +60,6 @@ public class PlanServiceTest {
     // 테스트 데이터
     private PlanCreateRequestDTO validRequestDTO;
     private Plan validPlan;
-    private Goal validGoal;
-    private SubGoal validSubGoal;
     private PlanResponseDTO validResponseDTO;
     private List<Plan> validPlanList;
     private List<PlanResponseDTO> validPlanResponseList;
@@ -70,17 +68,6 @@ public class PlanServiceTest {
     @BeforeEach
     void setUp() {
         // 테스트 데이터 초기화
-        validGoal = Goal.builder()
-            .goalId(1L)
-            .title("테스트 목표")
-            .build();
-
-        validSubGoal = SubGoal.builder()
-            .subGoalId(1L)
-            .goal(validGoal)
-            .title("테스트 서브목표")
-            .isCompleted(false)
-            .build();
 
         validRequestDTO = PlanCreateRequestDTO.builder()
             .title("테스트 일정")
@@ -93,8 +80,6 @@ public class PlanServiceTest {
 
         validPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .title("테스트 일정")
             .planCategory(PlanCategory.WORK)
             .color(Color.BLUE)
@@ -106,8 +91,6 @@ public class PlanServiceTest {
 
         validResponseDTO = PlanResponseDTO.builder()
             .planId(1L)
-            .goalId(1L)
-            .subGoalId(1L)
             .title("테스트 일정")
             .planCategory(PlanCategory.WORK)
             .color(Color.BLUE)
@@ -119,8 +102,6 @@ public class PlanServiceTest {
 
         Plan plan2 = Plan.builder()
             .planId(2L)
-            .goal(null)
-            .subGoal(null)
             .title("독립 일정")
             .planCategory(PlanCategory.STUDY)
             .color(Color.GREEN)
@@ -134,8 +115,6 @@ public class PlanServiceTest {
 
         PlanResponseDTO responseDTO2 = PlanResponseDTO.builder()
             .planId(2L)
-            .goalId(null)
-            .subGoalId(null)
             .title("독립 일정")
             .planCategory(PlanCategory.STUDY)
             .color(Color.GREEN)
@@ -159,20 +138,14 @@ public class PlanServiceTest {
     void createPlan_Success() {
         // given
         Long userId = 1L;
-        Long subGoalId = 10L;
 
-        doNothing().when(planValidator).validatePlanCreation(validRequestDTO, subGoalId);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
-        when(planConverter.toEntity(eq(validRequestDTO), eq(validGoal), eq(validSubGoal),
-            any(User.class))).thenReturn(
-            validPlan);
+        doNothing().when(planValidator).validatePlanCreation(validRequestDTO);
+        when(planConverter.toEntity(eq(validRequestDTO), any(User.class))).thenReturn(validPlan);
         when(planRepositoryFacade.savePlan(validPlan)).thenReturn(validPlan);
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.createPlan(validRequestDTO, userId, subGoalId);
+        PlanResponseDTO result = planService.createPlan(validRequestDTO, userId);
 
         // then
         assertThat(result).isNotNull();
@@ -180,27 +153,6 @@ public class PlanServiceTest {
         assertThat(result.getTitle()).isEqualTo("테스트 일정");
         assertThat(result.getPlanCategory()).isEqualTo(PlanCategory.WORK);
         assertThat(result.getColor()).isEqualTo(Color.BLUE);
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getSubGoalId()).isEqualTo(1L); // SubGoalId 검증도 추가
-    }
-
-    @Test
-    @DisplayName("일정 생성 실패 - SubGoal이 존재하지 않음")
-    void createPlan_Fail_SubGoalNotFound() {
-        // given
-        Long userId = 1L;
-        Long subGoalId = 999L; // goalId → subGoalId 변경
-
-        doNothing().when(planValidator).validatePlanCreation(validRequestDTO, subGoalId);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            null); // Mock 변경
-
-        // when & then
-        assertThatThrownBy(
-            () -> planService.createPlan(validRequestDTO, userId, subGoalId)) // 파라미터 변경
-            .isInstanceOf(PlanException.class)
-            .hasFieldOrPropertyWithValue("planExceptionType",
-                PlanExceptionType.PLAN_SUB_GOAL_NOT_FOUND); // 예외 타입 변경
     }
 
     @Test
@@ -208,13 +160,12 @@ public class PlanServiceTest {
     void createPlan_Fail_ValidationError() {
         // given
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         doThrow(new PlanException(PlanExceptionType.PLAN_TITLE_EMPTY))
-            .when(planValidator).validatePlanCreation(validRequestDTO, subGoalId);
+            .when(planValidator).validatePlanCreation(validRequestDTO);
 
         // when & then
-        assertThatThrownBy(() -> planService.createPlan(validRequestDTO, userId, subGoalId))
+        assertThatThrownBy(() -> planService.createPlan(validRequestDTO, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_TITLE_EMPTY);
     }
@@ -224,7 +175,6 @@ public class PlanServiceTest {
     void createPlan_Success_AllDay() {
         // given
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanCreateRequestDTO allDayRequest = PlanCreateRequestDTO.builder()
             .title("하루 종일 일정")
@@ -235,8 +185,6 @@ public class PlanServiceTest {
 
         Plan allDayPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .planCategory(PlanCategory.WORK)
             .color(Color.RED)
             .title("하루 종일 일정")
@@ -246,8 +194,6 @@ public class PlanServiceTest {
 
         PlanResponseDTO allDayResponse = PlanResponseDTO.builder()
             .planId(1L)
-            .goalId(1L)
-            .subGoalId(1L)
             .planCategory(PlanCategory.WORK)
             .color(Color.RED)
             .title("하루 종일 일정")
@@ -255,20 +201,13 @@ public class PlanServiceTest {
             .isCompleted(false)
             .build();
 
-        doNothing().when(planValidator).validatePlanCreation(allDayRequest, subGoalId);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
-        when(planConverter.toEntity(eq(allDayRequest), eq(validGoal), eq(validSubGoal),
-            any(User.class))).thenReturn(allDayPlan);
-//        when(planConverter.toEntity(allDayRequest, validGoal, validSubGoal)).thenReturn(allDayPlan);
+        doNothing().when(planValidator).validatePlanCreation(allDayRequest);
+        when(planConverter.toEntity(eq(allDayRequest), any(User.class))).thenReturn(allDayPlan);
         when(planRepositoryFacade.savePlan(allDayPlan)).thenReturn(allDayPlan);
         when(planConverter.toEntity(allDayPlan)).thenReturn(allDayResponse);
-//        when(goalConverter.toEntity(eq(minimalRequest), any(User.class))).thenReturn(
-//            validGoal);
 
         // when
-        PlanResponseDTO result = planService.createPlan(allDayRequest, userId, subGoalId);
+        PlanResponseDTO result = planService.createPlan(allDayRequest, userId);
 
         // then
         assertThat(result).isNotNull();
@@ -285,7 +224,6 @@ public class PlanServiceTest {
     void createPlan_Fail_AllDayFalse_NoDateTime() {
         // given
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanCreateRequestDTO invalidRequest = PlanCreateRequestDTO.builder()
             .title("시간 지정 일정")
@@ -294,18 +232,16 @@ public class PlanServiceTest {
             .build();
 
         doThrow(new PlanException(PlanExceptionType.PLAN_START_TIME_REQUIRED))
-            .when(planValidator).validatePlanCreation(invalidRequest, subGoalId);
+            .when(planValidator).validatePlanCreation(invalidRequest);
 
         // when & then
-        assertThatThrownBy(() -> planService.createPlan(invalidRequest, userId, subGoalId))
+        assertThatThrownBy(() -> planService.createPlan(invalidRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType",
                 PlanExceptionType.PLAN_START_TIME_REQUIRED);
 
-        verify(planValidator).validatePlanCreation(invalidRequest, subGoalId);
-        verify(subGoalRepositoryFacade, never()).findActiveSubGoalBySubGoalId(any());
-        verify(subGoalRepositoryFacade, never()).findActiveGoalBySubGoalId(any());
-        verify(planConverter, never()).toEntity(any(), any(), any());
+        verify(planValidator).validatePlanCreation(invalidRequest);
+        verify(planConverter, never()).toEntity(any(), any());
     }
 
     @Test
@@ -313,7 +249,6 @@ public class PlanServiceTest {
     void createPlan_Fail_InvalidTimeOrder() {
         // given
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanCreateRequestDTO invalidTimeRequest = PlanCreateRequestDTO.builder()
             .title("시간 순서 오류")
@@ -323,10 +258,10 @@ public class PlanServiceTest {
             .build();
 
         doThrow(new PlanException(PlanExceptionType.INVALID_PLAN_DATE_RANGE))
-            .when(planValidator).validatePlanCreation(invalidTimeRequest, subGoalId);
+            .when(planValidator).validatePlanCreation(invalidTimeRequest);
 
         // when & then
-        assertThatThrownBy(() -> planService.createPlan(invalidTimeRequest, userId, subGoalId))
+        assertThatThrownBy(() -> planService.createPlan(invalidTimeRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType",
                 PlanExceptionType.INVALID_PLAN_DATE_RANGE);
@@ -337,19 +272,13 @@ public class PlanServiceTest {
     void createPlan_Fail_RepositoryException() {
         // given
         Long userId = 1L;
-        Long subGoalId = 1L;
 
-        doNothing().when(planValidator).validatePlanCreation(validRequestDTO, subGoalId);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
-        when(planConverter.toEntity(eq(validRequestDTO), eq(validGoal), eq(validSubGoal),
-            any(User.class))).thenReturn(
-            validPlan);
+        doNothing().when(planValidator).validatePlanCreation(validRequestDTO);
+        when(planConverter.toEntity(eq(validRequestDTO), any(User.class))).thenReturn(validPlan);
         when(planRepositoryFacade.savePlan(validPlan)).thenThrow(new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> planService.createPlan(validRequestDTO, userId, subGoalId))
+        assertThatThrownBy(() -> planService.createPlan(validRequestDTO, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType",
                 PlanExceptionType.PLAN_CREATION_FAILED);
@@ -376,22 +305,18 @@ public class PlanServiceTest {
         assertThat(result.getPlans()).isNotNull();
         assertThat(result.getPlans()).hasSize(2);
 
-        // 첫 번째 일정 (Goal/SubGoal 연결된 일정)
+        // 첫 번째 일정
         PlanResponseDTO firstPlan = result.getPlans().getFirst();
         assertThat(firstPlan.getPlanId()).isEqualTo(1L);
         assertThat(firstPlan.getTitle()).isEqualTo("테스트 일정");
         assertThat(firstPlan.getColor()).isEqualTo(Color.BLUE);
-        assertThat(firstPlan.getGoalId()).isEqualTo(1L);
-        assertThat(firstPlan.getSubGoalId()).isEqualTo(1L);
         assertThat(firstPlan.getIsCompleted()).isFalse();
 
-        // 두 번째 일정 (독립 일정)
+        // 두 번째 일정
         PlanResponseDTO secondPlan = result.getPlans().get(1);
         assertThat(secondPlan.getPlanId()).isEqualTo(2L);
         assertThat(secondPlan.getTitle()).isEqualTo("독립 일정");
         assertThat(secondPlan.getColor()).isEqualTo(Color.GREEN);
-        assertThat(secondPlan.getGoalId()).isNull();
-        assertThat(secondPlan.getSubGoalId()).isNull();
         assertThat(secondPlan.getIsCompleted()).isFalse();
     }
 
@@ -459,33 +384,6 @@ public class PlanServiceTest {
     }
 
     @Test
-    @DisplayName("특정 일정 조회 성공 - Goal/SubGoal 연결된 일정")
-    void getPlanById_Success_WithGoalAndSubGoal() {
-        // given
-        Long planId = 1L;
-        Long userId = 1L;
-
-        doNothing().when(planValidator).validateGetPlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
-
-        // when
-        PlanResponseDTO result = planService.getPlanById(planId, userId);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getPlanId()).isEqualTo(1L);
-        assertThat(result.getTitle()).isEqualTo("테스트 일정");
-        assertThat(result.getPlanCategory()).isEqualTo(PlanCategory.WORK);
-        assertThat(result.getColor()).isEqualTo(Color.BLUE);
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getSubGoalId()).isEqualTo(1L);
-        assertThat(result.getAllDay()).isFalse();
-        assertThat(result.getIsCompleted()).isFalse();
-        verify(planValidator).validateGetPlan(planId);
-    }
-
-    @Test
     @DisplayName("특정 일정 조회 성공 - 독립 일정 (Goal/SubGoal 없음)")
     void getPlanById_Success_IndependentPlan() {
         // given
@@ -494,8 +392,6 @@ public class PlanServiceTest {
 
         Plan independentPlan = Plan.builder()
             .planId(2L)
-            .goal(null)
-            .subGoal(null)
             .title("독립 일정")
             .planCategory(PlanCategory.ETC)
             .color(Color.NAVY)
@@ -505,8 +401,6 @@ public class PlanServiceTest {
 
         PlanResponseDTO independentResponse = PlanResponseDTO.builder()
             .planId(2L)
-            .goalId(null)
-            .subGoalId(null)
             .title("독립 일정")
             .planCategory(PlanCategory.ETC)
             .color(Color.NAVY)
@@ -527,8 +421,6 @@ public class PlanServiceTest {
         assertThat(result.getTitle()).isEqualTo("독립 일정");
         assertThat(result.getPlanCategory()).isEqualTo(PlanCategory.ETC);
         assertThat(result.getColor()).isEqualTo(Color.NAVY);
-        assertThat(result.getGoalId()).isNull();
-        assertThat(result.getSubGoalId()).isNull();
         assertThat(result.getAllDay()).isTrue();
         verify(planValidator).validateGetPlan(planId);
     }
@@ -657,7 +549,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .title("수정된 제목")
@@ -665,25 +556,19 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doNothing().when(planValidator).validateTitle("수정된 제목");
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class)); // 아무 DTO나 반환
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
-            userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result).isEqualTo(validResponseDTO);
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateTitle("수정된 제목");
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
@@ -699,8 +584,6 @@ public class PlanServiceTest {
 
         PlanResponseDTO expectedUpdateResponse = PlanResponseDTO.builder()
             .planId(1L)
-            .goalId(1L)
-            .subGoalId(1L)
             .planCategory(PlanCategory.STUDY)
             .color(validPlan.getColor())
             .title("테스트 일정")
@@ -713,7 +596,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
         PlanCategory newCategory = PlanCategory.STUDY; // 기존 WORK에서 STUDY로 변경
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
@@ -722,17 +604,13 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
         when(planConverter.toEntity(validPlan)).thenReturn(expectedUpdateResponse);
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
-            userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
@@ -743,8 +621,6 @@ public class PlanServiceTest {
 
         verify(planValidator).validateUpdatePlan(planId);
         verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
 
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
@@ -768,8 +644,6 @@ public class PlanServiceTest {
 
         PlanResponseDTO expectedResponse = PlanResponseDTO.builder()
             .planId(validPlan.getPlanId())
-            .goalId(validPlan.getGoal().getGoalId())
-            .subGoalId(validPlan.getSubGoal().getSubGoalId())
             .title(validPlan.getTitle())
             .planCategory(validPlan.getPlanCategory())
             .color(newColor) // 색상만 새로운 값으로 변경
@@ -786,7 +660,7 @@ public class PlanServiceTest {
         when(planConverter.toEntity(validPlan)).thenReturn(expectedResponse);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, null, updateRequest, userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
@@ -800,7 +674,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         LocalDateTime newStartTime = LocalDateTime.of(2025, 8, 2, 14, 0);
         LocalDateTime newEndTime = LocalDateTime.of(2025, 8, 2, 16, 0);
@@ -812,24 +685,19 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doNothing().when(planValidator).validateDateRange(newStartTime, newEndTime);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest,
             userId);
 
         // then
         assertThat(result).isNotNull();
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateDateRange(newStartTime, newEndTime);
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
@@ -845,7 +713,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         LocalDateTime normalizedStartTime = LocalDateTime.of(2025, 8, 1, 0, 0);
         LocalDateTime normalizedEndTime = LocalDateTime.of(2025, 8, 1, 23, 59, 59);
@@ -856,9 +723,6 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doNothing().when(planValidator)
             .validateAllDayDateTime(true, normalizedStartTime, normalizedEndTime);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
@@ -866,15 +730,12 @@ public class PlanServiceTest {
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
-            userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateAllDayDateTime(true, normalizedStartTime, normalizedEndTime);
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
@@ -890,12 +751,9 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         Plan allDayPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .planCategory(PlanCategory.WORK)
             .title("하루 종일 일정")
             .startDateTime(LocalDateTime.of(2025, 8, 1, 0, 0))
@@ -910,9 +768,6 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(allDayPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doNothing().when(planValidator).validateAllDayDateTime(false, allDayPlan.getStartDateTime(),
             allDayPlan.getEndDateTime());
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
@@ -920,15 +775,13 @@ public class PlanServiceTest {
         when(planConverter.toEntity(allDayPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest,
             userId);
 
         // then
         assertThat(result).isNotNull();
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateAllDayDateTime(false, allDayPlan.getStartDateTime(),
             allDayPlan.getEndDateTime());
         verify(planConverter).toUpdatePlanRequestDTO(
@@ -945,7 +798,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .isCompleted(true)
@@ -953,23 +805,17 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
-            userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
             validPlan.getAllDay(),
@@ -984,12 +830,9 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         Plan completedPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .planCategory(PlanCategory.WORK)
             .title("완료된 일정")
             .startDateTime(validPlan.getStartDateTime())
@@ -1005,23 +848,17 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(completedPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(completedPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
-            userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
             completedPlan.getAllDay(),
@@ -1036,7 +873,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         LocalDateTime newStartTime = LocalDateTime.of(2025, 8, 3, 10, 0);
         LocalDateTime newEndTime = LocalDateTime.of(2025, 8, 3, 12, 0);
@@ -1058,23 +894,17 @@ public class PlanServiceTest {
         doNothing().when(planValidator).validateDateRange(newStartTime, newEndTime);
         doNothing().when(planValidator)
             .validateAllDayDateTime(true, normalizedStartTime, normalizedEndTime);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, updateRequest,
-            userId);
+        PlanResponseDTO result = planService.updatePlanById(planId, updateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateTitle("완전히 새로운 제목");
         verify(planValidator).validateDateRange(newStartTime, newEndTime);
         verify(planValidator).validateAllDayDateTime(true, normalizedStartTime, normalizedEndTime);
@@ -1092,7 +922,6 @@ public class PlanServiceTest {
         // given
         Long planId = 999L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .title("수정된 제목")
@@ -1103,7 +932,7 @@ public class PlanServiceTest {
 
         // when & then
         assertThatThrownBy(
-            () -> planService.updatePlanById(planId, subGoalId, updateRequest, userId))
+            () -> planService.updatePlanById(planId, updateRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_NOT_FOUND);
 
@@ -1118,7 +947,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .title("") // 빈 제목
@@ -1126,21 +954,16 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doThrow(new PlanException(PlanExceptionType.PLAN_TITLE_EMPTY))
             .when(planValidator).validateTitle("");
 
         // when & then
         assertThatThrownBy(
-            () -> planService.updatePlanById(planId, subGoalId, updateRequest, userId))
+            () -> planService.updatePlanById(planId, updateRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_TITLE_EMPTY);
 
         verify(planValidator).validateTitle("");
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planConverter, never()).toUpdatePlanRequestDTO(any(), any(), any(), any());
     }
 
@@ -1150,7 +973,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         LocalDateTime invalidStartTime = LocalDateTime.of(2025, 8, 1, 15, 0);
         LocalDateTime invalidEndTime = LocalDateTime.of(2025, 8, 1, 10, 0);
@@ -1162,21 +984,16 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doThrow(new PlanException(PlanExceptionType.INVALID_PLAN_DATE_RANGE))
             .when(planValidator).validateDateRange(invalidStartTime, invalidEndTime);
 
         // when & then
         assertThatThrownBy(
-            () -> planService.updatePlanById(planId, subGoalId, updateRequest, userId))
+            () -> planService.updatePlanById(planId, updateRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType",
                 PlanExceptionType.INVALID_PLAN_DATE_RANGE);
 
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateDateRange(invalidStartTime, invalidEndTime);
         verify(planConverter, never()).toUpdatePlanRequestDTO(any(), any(), any(), any());
     }
@@ -1187,7 +1004,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .allDay(true)
@@ -1195,21 +1011,16 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doThrow(new PlanException(PlanExceptionType.INVALID_PLAN_DATE_RANGE))
             .when(planValidator).validateAllDayDateTime(any(), any(), any());
 
         // when & then
         assertThatThrownBy(
-            () -> planService.updatePlanById(planId, subGoalId, updateRequest, userId))
+            () -> planService.updatePlanById(planId, updateRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType",
                 PlanExceptionType.INVALID_PLAN_DATE_RANGE);
 
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(subGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(subGoalId);
         verify(planValidator).validateAllDayDateTime(any(), any(), any());
         verify(planConverter, never()).toUpdatePlanRequestDTO(any(), any(), any(), any());
     }
@@ -1220,7 +1031,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .title("수정된 제목")
@@ -1232,7 +1042,7 @@ public class PlanServiceTest {
 
         // when & then
         assertThatThrownBy(
-            () -> planService.updatePlanById(planId, subGoalId, updateRequest, userId))
+            () -> planService.updatePlanById(planId, updateRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_UPDATE_FAILED);
 
@@ -1246,7 +1056,6 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
             .title("수정된 제목")
@@ -1254,16 +1063,13 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         doNothing().when(planValidator).validateTitle("수정된 제목");
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenThrow(new RuntimeException("변환 오류"));
 
         // when & then
         assertThatThrownBy(
-            () -> planService.updatePlanById(planId, subGoalId, updateRequest, userId))
+            () -> planService.updatePlanById(planId, updateRequest, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_UPDATE_FAILED);
     }
@@ -1274,21 +1080,17 @@ public class PlanServiceTest {
         // given
         Long planId = 1L;
         Long userId = 1L;
-        Long subGoalId = 1L;
 
         PlanUpdateRequestDTO emptyRequest = PlanUpdateRequestDTO.builder().build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
         when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId)).thenReturn(
-            validSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(subGoalId)).thenReturn(validGoal);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
 
         // when
-        PlanResponseDTO result = planService.updatePlanById(planId, subGoalId, emptyRequest,
+        PlanResponseDTO result = planService.updatePlanById(planId, emptyRequest,
             userId);
 
         // then
@@ -1304,81 +1106,6 @@ public class PlanServiceTest {
             validPlan.getStartDateTime(),
             validPlan.getEndDateTime()
         );
-    }
-
-    @Test
-    @DisplayName("일정 수정 성공 - subGoalId만 변경")
-    void updatePlanById_Success_SubGoalIdOnly() {
-        // given
-        Long planId = 1L;
-        Long userId = 1L;
-        Long newSubGoalId = 2L;
-
-        // 새로운 SubGoal과 Goal 생성
-        SubGoal newSubGoal = SubGoal.builder()
-            .subGoalId(2L)
-            .goal(validGoal)
-            .title("새로운 서브목표")
-            .isCompleted(false)
-            .build();
-
-        PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
-            .build(); // 빈 요청 (subGoalId만 변경)
-
-        doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(newSubGoalId)).thenReturn(
-            newSubGoal);
-        when(subGoalRepositoryFacade.findActiveGoalBySubGoalId(newSubGoalId)).thenReturn(validGoal);
-        when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
-            .thenReturn(mock(PlanUpdateRequestDTO.class));
-        when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
-
-        // when
-        PlanResponseDTO result = planService.updatePlanById(planId, newSubGoalId, updateRequest,
-            userId);
-
-        // then
-        assertThat(result).isNotNull();
-
-        verify(planValidator).validateUpdatePlan(planId);
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(newSubGoalId);
-        verify(subGoalRepositoryFacade).findActiveGoalBySubGoalId(newSubGoalId);
-        verify(planConverter).toUpdatePlanRequestDTO(
-            updateRequest,
-            validPlan.getAllDay(),
-            validPlan.getStartDateTime(),
-            validPlan.getEndDateTime()
-        );
-    }
-
-    @Test
-    @DisplayName("일정 수정 실패 - 존재하지 않는 subGoalId")
-    void updatePlanById_Fail_SubGoalNotFound() {
-        // given
-        Long planId = 1L;
-        Long userId = 1L;
-        Long invalidSubGoalId = 999L;
-
-        PlanUpdateRequestDTO updateRequest = PlanUpdateRequestDTO.builder()
-            .title("수정된 제목")
-            .build();
-
-        doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(invalidSubGoalId)).thenReturn(
-            null);
-
-        // when & then
-        assertThatThrownBy(
-            () -> planService.updatePlanById(planId, invalidSubGoalId, updateRequest, userId))
-            .isInstanceOf(PlanException.class)
-            .hasFieldOrPropertyWithValue("planExceptionType",
-                PlanExceptionType.PLAN_SUB_GOAL_NOT_FOUND);
-
-        verify(subGoalRepositoryFacade).findActiveSubGoalBySubGoalId(invalidSubGoalId);
-        verify(subGoalRepositoryFacade, never()).findActiveGoalBySubGoalId(any());
-        verify(planConverter, never()).toUpdatePlanRequestDTO(any(), any(), any(), any());
     }
 
     // ========== DELETE 테스트 ==========
@@ -1403,38 +1130,6 @@ public class PlanServiceTest {
         verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
     }
 
-    @Test
-    @DisplayName("일정 삭제 성공 - Goal/SubGoal과 연결된 일정")
-    void deletePlan_Success_WithGoalAndSubGoal() {
-        // given
-        Long planId = 1L;
-        Long userId = 1L;
-
-        Plan planWithRelations = Plan.builder()
-            .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
-            .title("목표와 연결된 일정")
-            .planCategory(PlanCategory.STUDY)
-            .color(Color.PINK)
-            .startDateTime(LocalDateTime.of(2025, 8, 1, 9, 0))
-            .endDateTime(LocalDateTime.of(2025, 8, 1, 10, 0))
-            .allDay(false)
-            .isCompleted(false)
-            .build();
-
-        doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(planWithRelations);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
-
-        // when
-        planService.deletePlan(planId, userId);
-
-        // then
-        verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
-    }
 
     @Test
     @DisplayName("일정 삭제 성공 - 독립 일정 (Goal/SubGoal 없음)")
@@ -1445,8 +1140,6 @@ public class PlanServiceTest {
 
         Plan independentPlan = Plan.builder()
             .planId(2L)
-            .goal(null)
-            .subGoal(null)
             .title("독립 일정")
             .planCategory(PlanCategory.STUDY)
             .color(Color.PINK)
@@ -1478,8 +1171,6 @@ public class PlanServiceTest {
 
         Plan completedPlan = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .title("완료된 일정")
             .planCategory(PlanCategory.WORK)
             .color(Color.PINK)
@@ -1512,8 +1203,6 @@ public class PlanServiceTest {
 
         Plan allDayPlan = Plan.builder()
             .planId(1L)
-            .goal(null)
-            .subGoal(null)
             .title("하루 종일 일정")
             .planCategory(PlanCategory.WORK)
             .color(Color.PINK)
@@ -1693,8 +1382,6 @@ public class PlanServiceTest {
         // SubPlan 리스트가 있는 Plan 생성 (실제로는 JPA Cascade가 처리)
         Plan planWithSubPlans = Plan.builder()
             .planId(1L)
-            .goal(validGoal)
-            .subGoal(validSubGoal)
             .title("SubPlan이 있는 일정")
             .planCategory(PlanCategory.WORK)
             .color(Color.PINK)

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/validator/PlanValidatorTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/validator/PlanValidatorTest.java
@@ -35,7 +35,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatCode(() -> planValidator.validatePlanCreation(validRequest, 1L))
+        assertThatCode(() -> planValidator.validatePlanCreation(validRequest))
             .doesNotThrowAnyException();
     }
 
@@ -51,7 +51,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatCode(() -> planValidator.validatePlanCreation(allDayRequest, 1L))
+        assertThatCode(() -> planValidator.validatePlanCreation(allDayRequest))
             .doesNotThrowAnyException();
     }
 
@@ -67,7 +67,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatCode(() -> planValidator.validatePlanCreation(allDayRequest, 1L))
+        assertThatCode(() -> planValidator.validatePlanCreation(allDayRequest))
             .doesNotThrowAnyException();
     }
 
@@ -83,7 +83,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatCode(() -> planValidator.validatePlanCreation(validRequest, null))
+        assertThatCode(() -> planValidator.validatePlanCreation(validRequest))
             .doesNotThrowAnyException();
     }
 
@@ -99,7 +99,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatCode(() -> planValidator.validatePlanCreation(validRequest, 1L))
+        assertThatCode(() -> planValidator.validatePlanCreation(validRequest))
             .doesNotThrowAnyException();
     }
 
@@ -114,7 +114,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_START_TIME_REQUIRED);
     }
@@ -130,7 +130,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_END_TIME_REQUIRED);
     }
@@ -146,7 +146,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_START_TIME_REQUIRED);
     }
@@ -162,7 +162,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_END_TIME_REQUIRED);
     }
@@ -179,7 +179,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.INVALID_PLAN_DATE_RANGE);
     }
@@ -196,7 +196,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.INVALID_PLAN_DATE_RANGE);
     }
@@ -213,7 +213,7 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_TITLE_EMPTY);
     }
@@ -231,26 +231,9 @@ public class PlanValidatorTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest, 1L))
+        assertThatThrownBy(() -> planValidator.validatePlanCreation(invalidRequest))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_TITLE_TOO_LONG);
-    }
-
-    @Test
-    @DisplayName("유효성 검사 실패 - subGoalId가 0 이하")
-    void validatePlanCreation_Fail_InvalidSubGoalId() {
-        // given
-        PlanCreateRequestDTO validRequest = PlanCreateRequestDTO.builder()
-            .title("테스트 일정")
-            .startDateTime(LocalDateTime.of(2025, 8, 1, 9, 0))
-            .endDateTime(LocalDateTime.of(2025, 8, 1, 10, 0))
-            .allDay(false)
-            .build();
-
-        // when & then
-        assertThatThrownBy(() -> planValidator.validatePlanCreation(validRequest, 0L))
-            .isInstanceOf(PlanException.class)
-            .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_INVALID_GOAL_ID);
     }
 
     // ========== GET 관련 테스트 (validateGetPlan) ==========


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #133 

## 🚀 작업 내용
- [x] domain에서 외래 키 삭제, Converter, DTO, ServiceImpl, Controller, test 등 관련 로직 내용 삭제
- [x] PlanConverterTest.java, PlanServiceTest.java, PlanValidatorTest.java, 
- [x] changelog 작성 changelog/changes/006-drop-plans-columns.yaml
- [x] enum PlanCategory에 '운동, 휴식, 건강, 중요, 에너지, 음악, 사진, 게임" 추가.


## 🔍 리뷰 요청 사항 및 공유자료
goal, subgoal 요소가 다 지워지지 않은 곳이 있는지

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
15+
