### PR TITLE
[refector] 로그인 관련 리팩토링

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.hotpack.krocs.domain.auth.controller;
 
-import com.hotpack.krocs.domain.auth.dto.UserSession;
+import com.hotpack.krocs.domain.auth.dto.response.UserResponseDTO;
 import com.hotpack.krocs.domain.auth.service.AuthService;
 import com.hotpack.krocs.domain.auth.service.RedisTokenService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
@@ -8,7 +8,6 @@ import com.hotpack.krocs.global.security.annotation.Login;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,11 +23,13 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserSession>> me(@Login UserSession userSession) {
-        if (userSession == null) {
-            return ResponseEntity.status(401).body(ApiResponse.onFailure("GLOBAL401", "인증 실패"));
+    public ApiResponse<UserResponseDTO> me(@Login Long userId) {
+        if (userId == null) {
+            return ApiResponse.onFailure("GLOBAL401", "인증 실패");
         }
-        return ResponseEntity.ok(ApiResponse.success(userSession));
+
+        UserResponseDTO responseDto = authService.getUser(userId);
+        return ApiResponse.success(responseDto);
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/hotpack/krocs/domain/auth/dto/response/UserResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/auth/dto/response/UserResponseDTO.java
@@ -1,0 +1,18 @@
+package com.hotpack.krocs.domain.auth.dto.response;
+
+import com.hotpack.krocs.domain.user.domain.enums.AccountType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDTO {
+
+    private Long userId;
+
+    private String name;
+
+    private String email;
+
+    private AccountType accountType;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/auth/exception/AuthException.java
@@ -1,0 +1,16 @@
+package com.hotpack.krocs.domain.auth.exception;
+
+import com.hotpack.krocs.global.common.response.exception.GeneralException;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends GeneralException {
+
+    private final AuthExceptionType authExceptionType;
+
+
+    public AuthException(AuthExceptionType authExceptionType) {
+        super(authExceptionType);
+        this.authExceptionType = authExceptionType;
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/auth/exception/AuthExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/auth/exception/AuthExceptionType.java
@@ -1,0 +1,38 @@
+package com.hotpack.krocs.domain.auth.exception;
+
+import com.hotpack.krocs.global.common.response.code.BaseCode;
+import com.hotpack.krocs.global.common.response.code.Reason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthExceptionType implements BaseCode {
+    AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH500", "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data("")
+            .build();
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/auth/service/AuthService.java
@@ -1,14 +1,23 @@
 package com.hotpack.krocs.domain.auth.service;
 
+import com.hotpack.krocs.domain.auth.dto.response.UserResponseDTO;
+import com.hotpack.krocs.domain.auth.exception.AuthException;
+import com.hotpack.krocs.domain.auth.exception.AuthExceptionType;
+import com.hotpack.krocs.domain.user.converter.UserConverter;
+import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
 
     private final RedisTokenService redisTokenService;
+    private final UserRepositoryFacade userRepositoryFacade;
 
     public ResponseCookie expireAuthTokenCookie() {
         return ResponseCookie.from("AUTH-TOKEN", "")
@@ -18,5 +27,15 @@ public class AuthService {
             .path("/")
             .maxAge(0)
             .build();
+    }
+
+
+    public UserResponseDTO getUser(Long userId) {
+        User user = userRepositoryFacade.findActiveUserByUserId(userId);
+        if (user == null) {
+            throw new AuthException(AuthExceptionType.AUTH_USER_NOT_FOUND);
+        }
+
+        return UserConverter.toUserResponseDTO(user);
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
@@ -2,21 +2,14 @@ package com.hotpack.krocs.domain.goals.controller;
 
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
-import com.hotpack.krocs.domain.goals.exception.SubGoalException;
-import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.service.GoalService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
 import com.hotpack.krocs.global.security.annotation.Login;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
@@ -59,48 +52,6 @@ public class GoalController {
         } catch (Exception e) {
             throw new GoalException(GoalExceptionType.GOAL_CREATION_FAILED);
         }
-    }
-
-    @Operation(summary = "소목표 생성", description = "소목표를 생성합니다.")
-    @PostMapping("/{goalId}/subgoals")
-    public ApiResponse<SubGoalCreateResponseDTO> createSubGoals(
-        @Login Long userId,
-        @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
-        Long goalId,
-        @Valid @RequestBody @Parameter(description = "SubGoals", example = "{\"title\": \"소목표1\"}")
-        SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
-        try {
-            SubGoalCreateResponseDTO responseDTO = goalService.createSubGoals(userId, goalId,
-                subGoalCreateRequestDTO);
-
-            return ApiResponse.success(responseDTO);
-        } catch (SubGoalException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
-        }
-    }
-
-    @GetMapping("/{goalId}/subgoals")
-    public ApiResponse<SubGoalListResponseDTO> getSubGoals(
-        @Login Long userId,
-        @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
-        Long goalId
-    ) {
-        SubGoalListResponseDTO response = goalService.getAllSubGoals(userId, goalId);
-        return ApiResponse.success(response);
-    }
-
-    @GetMapping("/{goalId}/subgoals/{subGoalId}")
-    public ApiResponse<SubGoalResponseDTO> getSubGoal(
-        @Login Long userId,
-        @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
-        Long goalId,
-        @PathVariable @Parameter(description = "SubGoal ID", example = "23") @Positive(message = "{common.id.positive}")
-        Long subGoalId
-    ) {
-        SubGoalResponseDTO response = goalService.getSubGoal(userId, goalId, subGoalId);
-        return ApiResponse.success(response);
     }
 
     @Operation(summary = "대목표 목록 조회", description = "사용자의 대목표 목록을 조회합니다."

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
@@ -70,7 +70,6 @@ public class GoalController {
         @Valid @RequestBody @Parameter(description = "SubGoals", example = "{\"title\": \"소목표1\"}")
         SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
         try {
-            // todo
             SubGoalCreateResponseDTO responseDTO = goalService.createSubGoals(userId, goalId,
                 subGoalCreateRequestDTO);
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
@@ -1,6 +1,5 @@
 package com.hotpack.krocs.domain.goals.controller;
 
-import com.hotpack.krocs.domain.auth.dto.UserSession;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
@@ -50,10 +49,9 @@ public class GoalController {
     @PostMapping
     public ApiResponse<GoalCreateResponseDTO> createGoal(
         @Valid @RequestBody GoalCreateRequestDTO requestDTO,
-        @Login UserSession user
+        @Login Long userId
     ) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             GoalCreateResponseDTO responseDTO = goalService.createGoal(requestDTO, userId);
             return ApiResponse.success(responseDTO);
         } catch (GoalException e) {
@@ -66,12 +64,14 @@ public class GoalController {
     @Operation(summary = "소목표 생성", description = "소목표를 생성합니다.")
     @PostMapping("/{goalId}/subgoals")
     public ApiResponse<SubGoalCreateResponseDTO> createSubGoals(
+        @Login Long userId,
         @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
         Long goalId,
         @Valid @RequestBody @Parameter(description = "SubGoals", example = "{\"title\": \"소목표1\"}")
         SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
         try {
-            SubGoalCreateResponseDTO responseDTO = goalService.createSubGoals(goalId,
+            // todo
+            SubGoalCreateResponseDTO responseDTO = goalService.createSubGoals(userId, goalId,
                 subGoalCreateRequestDTO);
 
             return ApiResponse.success(responseDTO);
@@ -84,21 +84,23 @@ public class GoalController {
 
     @GetMapping("/{goalId}/subgoals")
     public ApiResponse<SubGoalListResponseDTO> getSubGoals(
+        @Login Long userId,
         @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
         Long goalId
     ) {
-        SubGoalListResponseDTO response = goalService.getAllSubGoals(goalId);
+        SubGoalListResponseDTO response = goalService.getAllSubGoals(userId, goalId);
         return ApiResponse.success(response);
     }
 
     @GetMapping("/{goalId}/subgoals/{subGoalId}")
     public ApiResponse<SubGoalResponseDTO> getSubGoal(
+        @Login Long userId,
         @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
         Long goalId,
         @PathVariable @Parameter(description = "SubGoal ID", example = "23") @Positive(message = "{common.id.positive}")
         Long subGoalId
     ) {
-        SubGoalResponseDTO response = goalService.getSubGoal(goalId, subGoalId);
+        SubGoalResponseDTO response = goalService.getSubGoal(userId, goalId, subGoalId);
         return ApiResponse.success(response);
     }
 
@@ -106,13 +108,12 @@ public class GoalController {
     )
     @GetMapping
     public ApiResponse<List<GoalResponseDTO>> getGoal(
-        @Login UserSession user, @RequestParam(required = false) LocalDate date
+        @Login Long userId, @RequestParam(required = false) LocalDate date
     ) {
         try {
             if (date == null) {
                 date = LocalDate.now();
             }
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             List<GoalResponseDTO> responseDTO = goalService.getGoalByUser(userId, date);
             return ApiResponse.success(responseDTO);
         } catch (GoalException e) {
@@ -127,9 +128,8 @@ public class GoalController {
     @GetMapping("/{goalId}")
     public ApiResponse<GoalResponseDTO> getGoalById(
         @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
-        @Login UserSession user) {
+        @Login Long userId) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             GoalResponseDTO responseDTO = goalService.getGoalByGoalId(userId, goalId);
             return ApiResponse.success(responseDTO);
         } catch (GoalException e) {
@@ -145,9 +145,8 @@ public class GoalController {
     public ApiResponse<GoalResponseDTO> updateGoalById(
         @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
         @Valid @RequestBody GoalUpdateRequestDTO request,
-        @Login UserSession user) {
+        @Login Long userId) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             GoalResponseDTO responseDTO = goalService.updateGoalById(goalId, request, userId);
 
             return ApiResponse.success(responseDTO);
@@ -163,9 +162,8 @@ public class GoalController {
     @DeleteMapping("/{goalId}")
     public ApiResponse<Void> deleteGoal(
         @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
-        @Login UserSession user) {
+        @Login Long userId) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             goalService.deleteGoal(userId, goalId);
             return ApiResponse.success();
         } catch (GoalException e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/SubGoalController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/SubGoalController.java
@@ -1,58 +1,102 @@
 package com.hotpack.krocs.domain.goals.controller;
 
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalUpdateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalUpdateResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
+import com.hotpack.krocs.domain.goals.service.GoalService;
 import com.hotpack.krocs.domain.goals.service.SubGoalService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
+import com.hotpack.krocs.global.security.annotation.Login;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/subgoals")
+@RequestMapping("/api/v1/goals")
 @RequiredArgsConstructor
 @Validated
 public class SubGoalController {
 
-  private final SubGoalService subGoalService;
+    private final SubGoalService subGoalService;
+    private final GoalService goalService;
 
+    @Operation(summary = "소목표 생성", description = "소목표를 생성합니다.")
+    @PostMapping("/{goalId}/subgoals")
+    public ApiResponse<SubGoalCreateResponseDTO> createSubGoals(
+        @Login Long userId,
+        @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
+        Long goalId,
+        @Valid @RequestBody @Parameter(description = "SubGoals", example = "{\"title\": \"소목표1\"}")
+        SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
+        try {
+            SubGoalCreateResponseDTO responseDTO = goalService.createSubGoals(userId, goalId,
+                subGoalCreateRequestDTO);
 
-  @PatchMapping("/{subGoalId}")
-  public ApiResponse<SubGoalUpdateResponseDTO> updateSubGoal(
-      @PathVariable @Positive(message = "{common.id.positive}") Long subGoalId,
-      @Valid @RequestBody SubGoalUpdateRequestDTO request
-  ) {
-    try {
-      SubGoalUpdateResponseDTO responseDTO = subGoalService.updateSubGoal(subGoalId, request);
-      return ApiResponse.success(responseDTO);
-    } catch (SubGoalException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_UPDATE_FAILED);
+            return ApiResponse.success(responseDTO);
+        } catch (SubGoalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
+        }
     }
-  }
 
-  @DeleteMapping("/{subGoalId}")
-  public ApiResponse<Void> deleteSubGoal(
-      @PathVariable @Positive(message = "{common.id.positive}") Long subGoalId
-  ) {
-    try {
-      subGoalService.deleteSubGoal(subGoalId);
-      return ApiResponse.success();
-    } catch (SubGoalException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_DELETE_FAILED);
+    @GetMapping("/{goalId}/subgoals")
+    public ApiResponse<SubGoalListResponseDTO> getSubGoals(
+        @Login Long userId,
+        @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
+        Long goalId
+    ) {
+        SubGoalListResponseDTO response = goalService.getAllSubGoals(userId, goalId);
+        return ApiResponse.success(response);
     }
-  }
+
+    @PatchMapping("/{goalId}/subgoals/{subGoalId}")
+    public ApiResponse<SubGoalUpdateResponseDTO> updateSubGoal(
+        @Login Long userId,
+        @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
+        @PathVariable @Positive(message = "{common.id.positive}") Long subGoalId,
+        @Valid @RequestBody SubGoalUpdateRequestDTO request
+    ) {
+        try {
+            SubGoalUpdateResponseDTO responseDTO = subGoalService.updateSubGoal(userId, goalId,
+                subGoalId, request);
+            return ApiResponse.success(responseDTO);
+        } catch (SubGoalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_UPDATE_FAILED);
+        }
+    }
+
+    @DeleteMapping("/{goalId}/subgoals/{subGoalId}")
+    public ApiResponse<Void> deleteSubGoal(
+        @Login Long userId,
+        @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
+        @PathVariable @Positive(message = "{common.id.positive}") Long subGoalId
+    ) {
+        try {
+            subGoalService.deleteSubGoal(userId, goalId, subGoalId);
+            return ApiResponse.success();
+        } catch (SubGoalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_DELETE_FAILED);
+        }
+    }
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/SubGoalController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/SubGoalController.java
@@ -7,7 +7,6 @@ import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalUpdateResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
-import com.hotpack.krocs.domain.goals.service.GoalService;
 import com.hotpack.krocs.domain.goals.service.SubGoalService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
 import com.hotpack.krocs.global.security.annotation.Login;
@@ -33,7 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SubGoalController {
 
     private final SubGoalService subGoalService;
-    private final GoalService goalService;
 
     @Operation(summary = "소목표 생성", description = "소목표를 생성합니다.")
     @PostMapping("/{goalId}/subgoals")
@@ -44,7 +42,7 @@ public class SubGoalController {
         @Valid @RequestBody @Parameter(description = "SubGoals", example = "{\"title\": \"소목표1\"}")
         SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
         try {
-            SubGoalCreateResponseDTO responseDTO = goalService.createSubGoals(userId, goalId,
+            SubGoalCreateResponseDTO responseDTO = subGoalService.createSubGoals(userId, goalId,
                 subGoalCreateRequestDTO);
 
             return ApiResponse.success(responseDTO);
@@ -61,7 +59,7 @@ public class SubGoalController {
         @PathVariable @Parameter(description = "Goal ID", example = "1") @Positive(message = "{common.id.positive}")
         Long goalId
     ) {
-        SubGoalListResponseDTO response = goalService.getAllSubGoals(userId, goalId);
+        SubGoalListResponseDTO response = subGoalService.getAllSubGoals(userId, goalId);
         return ApiResponse.success(response);
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/GoalCreateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/GoalCreateResponseDTO.java
@@ -14,8 +14,6 @@ public class GoalCreateResponseDTO {
 
     private final Long goalId;
 
-    private final Long userId;
-
     private final String title;
 
     private final Priority priority;

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/exception/GoalExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/exception/GoalExceptionType.java
@@ -14,6 +14,7 @@ public enum GoalExceptionType implements BaseCode {
     GOAL_FOUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GOAL500", "목표 조회에 실패했습니다."),
     GOAL_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GOAL500", "목표 삭제에 실패했습니다."),
     GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "GOAL404", "목표를 찾을 수 없습니다."),
+    GOAL_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "GOAL404", "사용자를 찾을 수 없습니다."),
     GOAL_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "GOAL400", "이미 완료된 목표입니다."),
     INVALID_GOAL_DATE_RANGE(HttpStatus.BAD_REQUEST, "GOAL400", "유효하지 않은 목표 기간입니다."),
     GOAL_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "GOAL400", "목표 제목은 필수입니다."),
@@ -30,21 +31,21 @@ public enum GoalExceptionType implements BaseCode {
     @Override
     public Reason getReason() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
     }
 
     @Override
     public Reason getReasonHttpStatus() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data("")
+            .build();
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/exception/SubGoalExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/exception/SubGoalExceptionType.java
@@ -9,47 +9,48 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SubGoalExceptionType implements BaseCode {
-  SUB_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBGOAL404", "소목표를 찾을 수 없습니다."),
-  SUB_GOAL_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBGOAL404", "상위 대목표를 찾을 수 없습니다."),
-  SUB_GOAL_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "SUBGOAL400", "이미 완료된 소목표입니다."),
-  SUB_GOAL_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표 제목은 필수입니다."),
-  SUB_GOAL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 생성에 실패했습니다."),
-  SUB_GOAL_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "SUBGOAL400", "목표 제목이 너무 깁니다."),
-  SUB_GOAL_GOAL_ID_MISSING(HttpStatus.BAD_REQUEST, "SUBGOAL400", "상위 목표(goalId)는 필수입니다."),
-  SUB_GOAL_UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "SUBGOAL401", "소목표에 대한 접근 권한이 없습니다."),
-  SUB_GOAL_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 생성에 실패했습니다."),
-  SUB_GOAL_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 수정에 실패했습니다."),
-  SUB_GOAL_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 삭제에 실패했습니다."),
-  SUB_GOAL_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 조회에 실패했습니다."),
-  SUB_GOAL_INVALID_STATE(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표의 상태가 유효하지 않습니다."),
-  SUB_GOAL_INVALID_ID_FORMAT(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표 ID 형식이 잘못되었습니다."),
-  SUB_GOAL_CREATE_EMPTY(HttpStatus.BAD_REQUEST, "SUBGOAL400", "생성할 소목표가 없습니다."),
-  SUB_GOAL_GOAL_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBGOAL400", "대목표 ID가 null 입니다."),
-  SUB_GOAL_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표 ID가 null 입니다."),
-  SUB_GOAL_NOT_BELONG_TO_GOAL(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표가 해당 목표에 속하지 않습니다.");
+    SUB_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBGOAL404", "소목표를 찾을 수 없습니다."),
+    SUB_GOAL_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBGOAL404", "상위 대목표를 찾을 수 없습니다."),
+    SUB_GOAL_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "SUBGOAL400", "이미 완료된 소목표입니다."),
+    SUB_GOAL_TITLE_EMPTY(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표 제목은 필수입니다."),
+    SUB_GOAL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 생성에 실패했습니다."),
+    SUB_GOAL_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "SUBGOAL400", "목표 제목이 너무 깁니다."),
+    SUB_GOAL_GOAL_ID_MISSING(HttpStatus.BAD_REQUEST, "SUBGOAL400", "상위 목표(goalId)는 필수입니다."),
+    SUB_GOAL_UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "SUBGOAL401", "소목표에 대한 접근 권한이 없습니다."),
+    SUB_GOAL_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 생성에 실패했습니다."),
+    SUB_GOAL_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 수정에 실패했습니다."),
+    SUB_GOAL_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 삭제에 실패했습니다."),
+    SUB_GOAL_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBGOAL500", "소목표 조회에 실패했습니다."),
+    SUB_GOAL_INVALID_STATE(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표의 상태가 유효하지 않습니다."),
+    SUB_GOAL_INVALID_ID_FORMAT(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표 ID 형식이 잘못되었습니다."),
+    SUB_GOAL_CREATE_EMPTY(HttpStatus.BAD_REQUEST, "SUBGOAL400", "생성할 소목표가 없습니다."),
+    SUB_GOAL_GOAL_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBGOAL400", "대목표 ID가 null 입니다."),
+    SUB_GOAL_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표 ID가 null 입니다."),
+    SUB_GOAL_NOT_BELONG_TO_GOAL(HttpStatus.BAD_REQUEST, "SUBGOAL400", "소목표가 해당 목표에 속하지 않습니다."),
+    SUB_GOAL_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBGOAL404", "해당 소목표에 접근할 수 없습니다.");
 
-  private final HttpStatus httpStatus;
-  private final String code;
-  private final String message;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
 
-  @Override
-  public Reason getReason() {
-    return Reason.builder()
-        .message(message)
-        .code(code)
-        .isSuccess(false)
-        .data("")
-        .build();
-  }
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
+    }
 
-  @Override
-  public Reason getReasonHttpStatus() {
-    return Reason.builder()
-        .message(message)
-        .code(code)
-        .isSuccess(false)
-        .httpStatus(httpStatus)
-        .data("")
-        .build();
-  }
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data("")
+            .build();
+    }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
@@ -1,11 +1,8 @@
 package com.hotpack.krocs.domain.goals.facade;
 
 import com.hotpack.krocs.domain.goals.domain.Goal;
-import com.hotpack.krocs.domain.goals.exception.SubGoalException;
-import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.repository.GoalRepository;
-import com.hotpack.krocs.domain.plans.exception.SubPlanException;
-import com.hotpack.krocs.domain.plans.exception.SubPlanExceptionType;
+import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.time.LocalDate;
 import java.util.List;
@@ -27,16 +24,16 @@ public class GoalRepositoryFacade {
         return goalRepository.save(goal);
     }
 
-    public List<Goal> findActiveGoalByDate(LocalDate date) {
-        return goalRepository.findGoalByDateAndStatus(date, Status.ACTIVE);
+    public List<Goal> findActiveGoalByUserAndDate(User user, LocalDate date) {
+        return goalRepository.findGoalByUserIdAndDateAndStatus(user, date, Status.ACTIVE);
     }
 
-    public List<Goal> findAllActiveGoals() {
-        return goalRepository.findAllGoalsByStatus(Status.ACTIVE);
+    public List<Goal> findAllActiveGoalsByUser(User user) {
+        return goalRepository.findAllGoalsByUserAndStatus(user, Status.ACTIVE);
     }
 
-    public Goal findActiveGoalById(Long goalId) {
-        return goalRepository.findGoalByGoalIdAndStatus(goalId, Status.ACTIVE);
+    public Goal findActiveGoalByUserAndGoalId(User user, Long goalId) {
+        return goalRepository.findGoalByUserAndGoalIdAndStatus(user, goalId, Status.ACTIVE);
     }
 
     @Transactional
@@ -47,9 +44,4 @@ public class GoalRepositoryFacade {
     public boolean existsActiveGoalById(Long goalId) {
         return goalRepository.existsGoalByGoalIdAndStatus(goalId, Status.ACTIVE);
     }
-
-    public boolean existsActiveGoalByTitleAndGoalIdNot(String title, Long goalId) {
-        return goalRepository.existsByTitleAndGoalIdNotAndStatus(title, goalId, Status.ACTIVE);
-    }
-
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
@@ -36,14 +36,6 @@ public class GoalRepositoryFacade {
         return goalRepository.findGoalsWithFilters(userId, keyword, searchDate);
     }
 
-    public List<Goal> findCompleteGoalByDate(LocalDate date) {
-        return goalRepository.findGoalByDateAndStatus(date, Status.INACTIVE);
-    }
-
-    public List<Goal> findAllActiveGoals() {
-        return goalRepository.findAllGoalsByStatus(Status.ACTIVE);
-    }
-
     public Goal findActiveGoalByUserAndGoalId(User user, Long goalId) {
         return goalRepository.findGoalByUserAndGoalIdAndStatus(user, goalId, Status.ACTIVE);
     }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/SubGoalRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/SubGoalRepositoryFacade.java
@@ -25,11 +25,6 @@ public class SubGoalRepositoryFacade {
         return subGoalRepository.saveAll(subGoals);
     }
 
-    @Transactional
-    public SubGoal saveSubGoal(SubGoal subGoal) {
-        return subGoalRepository.save(subGoal);
-    }
-
     public List<SubGoal> findActiveSubGoalsByGoal(Goal goal) {
         return subGoalRepository.findSubGoalsByGoalAndStatus(goal, Status.ACTIVE);
     }
@@ -57,5 +52,11 @@ public class SubGoalRepositoryFacade {
         SubGoal subGoal = subGoalRepository.findSubGoalsBySubGoalIdAndStatus(subGoalId,
             Status.ACTIVE);
         return subGoal.getGoal();
+    }
+
+    public boolean existsValidSubGoal(Long userId, Long goalId,
+        Long subGoalId) {
+        return subGoalRepository.existsValidSubGoal(
+            userId, goalId, subGoalId, Status.ACTIVE);
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/GoalRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/GoalRepository.java
@@ -1,6 +1,7 @@
 package com.hotpack.krocs.domain.goals.repository;
 
 import com.hotpack.krocs.domain.goals.domain.Goal;
+import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.time.LocalDate;
 import java.util.List;
@@ -15,11 +16,12 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
     @Query("SELECT g FROM Goal g WHERE :date BETWEEN g.startDate AND g.endDate")
     List<Goal> findByDate(@Param("date") LocalDate date);
 
-    @Query("SELECT g FROM Goal g WHERE :date BETWEEN g.startDate AND g.endDate AND g.status = :status")
-    List<Goal> findGoalByDateAndStatus(@Param("date") LocalDate date,
+    @Query("SELECT g FROM Goal g WHERE :date BETWEEN g.startDate AND g.endDate AND g.status = :status AND g.user = :user")
+    List<Goal> findGoalByUserIdAndDateAndStatus(@Param("user") User user,
+        @Param("date") LocalDate date,
         @Param("status") Status status);
 
-    Goal findGoalByGoalIdAndStatus(Long goalId, Status status);
+    Goal findGoalByUserAndGoalIdAndStatus(User user, Long goalId, Status status);
 
     Goal findGoalByGoalId(Long goalId);
 
@@ -31,5 +33,5 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
 
     boolean existsByTitleAndGoalIdNotAndStatus(String title, Long goalId, Status status);
 
-    List<Goal> findAllGoalsByStatus(Status status);
+    List<Goal> findAllGoalsByUserAndStatus(User user, Status status);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/SubGoalRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/SubGoalRepository.java
@@ -6,6 +6,7 @@ import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,7 +18,7 @@ public interface SubGoalRepository extends JpaRepository<SubGoal, Long> {
 
     @Query(value = """
         SELECT EXISTS (
-            SELECT s
+            SELECT 1
             FROM sub_goal s
             JOIN goals g ON s.goal_id = g.goal_id
             JOIN users u ON g.user_id = u.user_id
@@ -27,7 +28,10 @@ public interface SubGoalRepository extends JpaRepository<SubGoal, Long> {
               AND s.status = :status
         )
         """, nativeQuery = true)
-    boolean existsValidSubGoal(Long userId,
-        Long goalId, Long subGoalId, Status status);
+    boolean existsValidSubGoal(
+        @Param("userId") Long userId,
+        @Param("goalId") Long goalId,
+        @Param("subGoalId") Long subGoalId,
+        @Param("status") Status status);
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/SubGoalRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/SubGoalRepository.java
@@ -5,6 +5,7 @@ import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,5 +14,20 @@ public interface SubGoalRepository extends JpaRepository<SubGoal, Long> {
     List<SubGoal> findSubGoalsByGoalAndStatus(Goal goal, Status status);
 
     SubGoal findSubGoalsBySubGoalIdAndStatus(Long subGoalId, Status status);
+
+    @Query(value = """
+        SELECT EXISTS (
+            SELECT s
+            FROM sub_goal s
+            JOIN goals g ON s.goal_id = g.goal_id
+            JOIN users u ON g.user_id = u.user_id
+            WHERE s.sub_goal_id = :subGoalId
+              AND g.goal_id = :goalId
+              AND u.user_id = :userId
+              AND s.status = :status
+        )
+        """, nativeQuery = true)
+    boolean existsValidSubGoal(Long userId,
+        Long goalId, Long subGoalId, Status status);
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
@@ -2,11 +2,8 @@ package com.hotpack.krocs.domain.goals.service;
 
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -21,9 +18,4 @@ public interface GoalService {
     GoalResponseDTO updateGoalById(Long goalId, GoalUpdateRequestDTO request, Long userId);
 
     void deleteGoal(Long userId, Long goalId);
-
-    SubGoalCreateResponseDTO createSubGoals(Long userId, Long goalId,
-        SubGoalCreateRequestDTO requestDTO);
-
-    SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
@@ -23,9 +23,10 @@ public interface GoalService {
 
     void deleteGoal(Long userId, Long goalId);
 
-    SubGoalCreateResponseDTO createSubGoals(Long goalId, SubGoalCreateRequestDTO requestDTO);
+    SubGoalCreateResponseDTO createSubGoals(Long userId, Long goalId,
+        SubGoalCreateRequestDTO requestDTO);
 
-    SubGoalListResponseDTO getAllSubGoals(Long goalId);
+    SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId);
 
-    SubGoalResponseDTO getSubGoal(Long goalId, Long subGoalId);
+    SubGoalResponseDTO getSubGoal(Long userId, Long goalId, Long subGoalId);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
@@ -7,7 +7,6 @@ import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -27,6 +26,4 @@ public interface GoalService {
         SubGoalCreateRequestDTO requestDTO);
 
     SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId);
-
-    SubGoalResponseDTO getSubGoal(Long userId, Long goalId, Long subGoalId);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
@@ -20,6 +20,7 @@ import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
 import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.constant.ValidationConstants;
 import java.time.LocalDate;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GoalServiceImpl implements GoalService {
 
     private final SubGoalRepositoryFacade subGoalRepositoryFacade;
+    private final UserRepositoryFacade userRepositoryFacade;
     private final SubGoalConverter subGoalConverter;
     private final GoalRepositoryFacade goalRepositoryFacade;
     private final GoalConverter goalConverter;
@@ -46,16 +48,12 @@ public class GoalServiceImpl implements GoalService {
     public GoalCreateResponseDTO createGoal(GoalCreateRequestDTO requestDTO, Long userId) {
         try {
             goalValidator.validateGoalCreation(requestDTO);
-
-            Goal goal;
-            if (userId != null) {
-                User userRef = User.builder()
-                    .userId(userId)
-                    .build();
-                goal = goalConverter.toEntity(requestDTO, userRef);
-            } else {
-                goal = goalConverter.toEntity(requestDTO);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
             }
+
+            Goal goal = goalConverter.toEntity(requestDTO, user);
             Goal savedGoal = goalRepositoryFacade.saveGoal(goal);
 
             return goalConverter.toCreateResponseDTO(savedGoal);
@@ -70,11 +68,16 @@ public class GoalServiceImpl implements GoalService {
     @Override
     public List<GoalResponseDTO> getGoalByUser(Long userId, LocalDate date) {
         try {
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
             List<Goal> goals;
             if (date != null) {
-                goals = goalRepositoryFacade.findActiveGoalByDate(date);
+                goals = goalRepositoryFacade.findActiveGoalByUserAndDate(user, date);
             } else {
-                goals = goalRepositoryFacade.findAllActiveGoals();
+                goals = goalRepositoryFacade.findAllActiveGoalsByUser(user);
             }
             return goalConverter.toGoalResponseDTO(goals);
         } catch (GoalException e) {
@@ -89,8 +92,12 @@ public class GoalServiceImpl implements GoalService {
     public GoalResponseDTO getGoalByGoalId(Long userId, Long goalId) {
         try {
             goalValidator.validateGoalIdParameter(goalId);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
 
-            Goal existingGoal = goalRepositoryFacade.findActiveGoalById(goalId);
+            Goal existingGoal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
             if (existingGoal == null) {
                 throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
             }
@@ -111,11 +118,17 @@ public class GoalServiceImpl implements GoalService {
         try {
             goalValidator.validateGoalIdParameter(goalId);
 
-            Goal existingGoal = goalRepositoryFacade.findActiveGoalById(goalId);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal existingGoal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
             if (existingGoal == null) {
                 throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
             }
 
+            // validator 추출
             if (requestDTO.getTitle() != null) {
                 goalValidator.validateTitle(requestDTO.getTitle());
             }
@@ -130,7 +143,7 @@ public class GoalServiceImpl implements GoalService {
             }
 
             existingGoal.updateFrom(requestDTO);
-            Goal updatedGoal = goalRepositoryFacade.findActiveGoalById(goalId);
+            Goal updatedGoal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
 
             return goalConverter.toGoalResponseDTO(updatedGoal);
 
@@ -151,7 +164,12 @@ public class GoalServiceImpl implements GoalService {
                 throw new GoalException(GoalExceptionType.GOAL_NOT_FOUND);
             }
 
-            Goal goal = goalRepositoryFacade.findActiveGoalById(goalId);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
             goal.delete();
 
         } catch (GoalException e) {
@@ -164,7 +182,7 @@ public class GoalServiceImpl implements GoalService {
 
     @Override
     @Transactional
-    public SubGoalCreateResponseDTO createSubGoals(Long goalId,
+    public SubGoalCreateResponseDTO createSubGoals(Long userId, Long goalId,
         SubGoalCreateRequestDTO requestDTO) {
         try {
             if (goalId == null) {
@@ -172,7 +190,12 @@ public class GoalServiceImpl implements GoalService {
             }
             validateSubGoalCreation(requestDTO);
 
-            Goal goal = goalRepositoryFacade.findActiveGoalById(goalId);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
             if (goal == null) {
                 throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
             }
@@ -212,13 +235,18 @@ public class GoalServiceImpl implements GoalService {
     }
 
     @Override
-    public SubGoalListResponseDTO getAllSubGoals(Long goalId) {
+    public SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId) {
         try {
             if (goalId == null) {
                 throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
             }
 
-            Goal goal = goalRepositoryFacade.findActiveGoalById(goalId);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
 
             List<SubGoal> subGoals = subGoalRepositoryFacade.findActiveSubGoalsByGoal(goal);
             List<SubGoalResponseDTO> subGoalResponseDTOS = subGoalConverter.toSubGoalResponseListDTO(
@@ -237,7 +265,7 @@ public class GoalServiceImpl implements GoalService {
     }
 
     @Override
-    public SubGoalResponseDTO getSubGoal(Long goalId, Long subGoalId) {
+    public SubGoalResponseDTO getSubGoal(Long userId, Long goalId, Long subGoalId) {
         try {
             if (goalId == null) {
                 throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
@@ -246,7 +274,12 @@ public class GoalServiceImpl implements GoalService {
                 throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
             }
 
-            Goal goal = goalRepositoryFacade.findActiveGoalById(goalId);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
             List<SubGoal> subGoals = subGoalRepositoryFacade.findActiveSubGoalsByGoal(goal);
             SubGoal subGoal = subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId);
             if (!subGoals.contains(subGoal)) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
@@ -263,35 +263,4 @@ public class GoalServiceImpl implements GoalService {
             throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
         }
     }
-
-    @Override
-    public SubGoalResponseDTO getSubGoal(Long userId, Long goalId, Long subGoalId) {
-        try {
-            if (goalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-            }
-            if (subGoalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
-            }
-
-            User user = userRepositoryFacade.findActiveUserByUserId(userId);
-            if (user == null) {
-                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
-            }
-
-            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
-            List<SubGoal> subGoals = subGoalRepositoryFacade.findActiveSubGoalsByGoal(goal);
-            SubGoal subGoal = subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId);
-            if (!subGoals.contains(subGoal)) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_BELONG_TO_GOAL);
-            }
-            return subGoalConverter.toSubGoalResponseDTO(subGoal);
-
-        } catch (SubGoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("소목표 단건 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
-        }
-    }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
@@ -1,27 +1,16 @@
 package com.hotpack.krocs.domain.goals.service;
 
 import com.hotpack.krocs.domain.goals.converter.GoalConverter;
-import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
 import com.hotpack.krocs.domain.goals.domain.Goal;
-import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
-import com.hotpack.krocs.domain.goals.exception.SubGoalException;
-import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
-import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
-import com.hotpack.krocs.global.common.constant.ValidationConstants;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GoalServiceImpl implements GoalService {
 
-    private final SubGoalRepositoryFacade subGoalRepositoryFacade;
     private final UserRepositoryFacade userRepositoryFacade;
-    private final SubGoalConverter subGoalConverter;
     private final GoalRepositoryFacade goalRepositoryFacade;
     private final GoalConverter goalConverter;
     private final GoalValidator goalValidator;
@@ -177,90 +164,6 @@ public class GoalServiceImpl implements GoalService {
         } catch (Exception e) {
             log.error("대목표 삭제 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
             throw new GoalException(GoalExceptionType.GOAL_DELETE_FAILED);
-        }
-    }
-
-    @Override
-    @Transactional
-    public SubGoalCreateResponseDTO createSubGoals(Long userId, Long goalId,
-        SubGoalCreateRequestDTO requestDTO) {
-        try {
-            if (goalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-            }
-            validateSubGoalCreation(requestDTO);
-
-            User user = userRepositoryFacade.findActiveUserByUserId(userId);
-            if (user == null) {
-                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
-            }
-
-            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
-            if (goal == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
-            }
-
-            List<SubGoal> subGoals = subGoalConverter.toSubGoalEntityList(goal, requestDTO);
-            List<SubGoal> createdSubGoals = subGoalRepositoryFacade.saveSubGoals(subGoals);
-            List<SubGoalResponseDTO> subGoalResponseDTOs = subGoalConverter.toSubGoalResponseListDTO(
-                createdSubGoals);
-
-            return SubGoalCreateResponseDTO
-                .builder()
-                .goalId(goalId)
-                .createdSubGoals(subGoalResponseDTOs)
-                .build();
-
-        } catch (SubGoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("소목표 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
-        }
-    }
-
-    private void validateSubGoalCreation(SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
-        if (subGoalCreateRequestDTO.getSubGoals().isEmpty()) {
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
-        }
-
-        for (SubGoalRequestDTO subGoalRequestDTO : subGoalCreateRequestDTO.getSubGoals()) {
-            if (subGoalRequestDTO.getTitle().isBlank()) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
-            }
-            if (subGoalRequestDTO.getTitle().length() > ValidationConstants.TITLE_MAX) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
-            }
-        }
-    }
-
-    @Override
-    public SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId) {
-        try {
-            if (goalId == null) {
-                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-            }
-
-            User user = userRepositoryFacade.findActiveUserByUserId(userId);
-            if (user == null) {
-                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
-            }
-
-            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
-
-            List<SubGoal> subGoals = subGoalRepositoryFacade.findActiveSubGoalsByGoal(goal);
-            List<SubGoalResponseDTO> subGoalResponseDTOS = subGoalConverter.toSubGoalResponseListDTO(
-                subGoals);
-
-            return SubGoalListResponseDTO
-                .builder()
-                .subGoals(subGoalResponseDTOS)
-                .build();
-        } catch (SubGoalException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("소목표 전체 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
         }
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/SubGoalService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/SubGoalService.java
@@ -1,11 +1,21 @@
 package com.hotpack.krocs.domain.goals.service;
 
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalUpdateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalUpdateResponseDTO;
 
 public interface SubGoalService {
 
-  SubGoalUpdateResponseDTO updateSubGoal(Long subGoalId, SubGoalUpdateRequestDTO requestDTO);
 
-  void deleteSubGoal(Long subGoalId);
+    SubGoalCreateResponseDTO createSubGoals(Long userId, Long goalId,
+        SubGoalCreateRequestDTO requestDTO);
+
+    SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId);
+
+    SubGoalUpdateResponseDTO updateSubGoal(Long userId, Long goalId, Long subGoalId,
+        SubGoalUpdateRequestDTO requestDTO);
+
+    void deleteSubGoal(Long userId, Long goalId, Long subGoalId);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceImpl.java
@@ -1,13 +1,25 @@
 package com.hotpack.krocs.domain.goals.service;
 
 import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
+import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalUpdateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalUpdateResponseDTO;
+import com.hotpack.krocs.domain.goals.exception.GoalException;
+import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
+import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
+import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.constant.ValidationConstants;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,16 +32,74 @@ public class SubGoalServiceImpl implements SubGoalService {
 
     private final SubGoalRepositoryFacade subGoalRepositoryFacade;
     private final SubGoalConverter subGoalConverter;
+    private final UserRepositoryFacade userRepositoryFacade;
+    private final GoalRepositoryFacade goalRepositoryFacade;
 
     @Override
     @Transactional
-    public SubGoalUpdateResponseDTO updateSubGoal(Long subGoalId,
+    public SubGoalCreateResponseDTO createSubGoals(Long userId, Long goalId,
+        SubGoalCreateRequestDTO requestDTO) {
+        try {
+            if (goalId == null) {
+                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
+            }
+            validateSubGoalCreation(requestDTO);
+
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
+            if (goal == null) {
+                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
+            }
+
+            List<SubGoal> subGoals = subGoalConverter.toSubGoalEntityList(goal, requestDTO);
+            List<SubGoal> createdSubGoals = subGoalRepositoryFacade.saveSubGoals(subGoals);
+            List<SubGoalResponseDTO> subGoalResponseDTOs = subGoalConverter.toSubGoalResponseListDTO(
+                createdSubGoals);
+
+            return SubGoalCreateResponseDTO
+                .builder()
+                .goalId(goalId)
+                .createdSubGoals(subGoalResponseDTOs)
+                .build();
+
+        } catch (SubGoalException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("소목표 생성 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
+        }
+    }
+
+    private void validateSubGoalCreation(SubGoalCreateRequestDTO subGoalCreateRequestDTO) {
+        if (subGoalCreateRequestDTO.getSubGoals().isEmpty()) {
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
+        }
+
+        for (SubGoalRequestDTO subGoalRequestDTO : subGoalCreateRequestDTO.getSubGoals()) {
+            if (subGoalRequestDTO.getTitle().isBlank()) {
+                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
+            }
+            if (subGoalRequestDTO.getTitle().length() > ValidationConstants.TITLE_MAX) {
+                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public SubGoalUpdateResponseDTO updateSubGoal(Long userId, Long goalId, Long subGoalId,
         SubGoalUpdateRequestDTO requestDTO) {
         try {
-            validateBusinessRules(requestDTO);
             if (subGoalId == null) {
                 throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
             }
+
+            validateSubGoalAccess(userId, goalId, subGoalId);
+            validateBusinessRules(requestDTO);
 
             SubGoal subGoal = subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(subGoalId);
             subGoal.updateFrom(requestDTO);
@@ -41,6 +111,36 @@ public class SubGoalServiceImpl implements SubGoalService {
         } catch (Exception e) {
             log.error("소목표 수정 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
             throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_UPDATE_FAILED);
+        }
+    }
+
+    @Override
+    public SubGoalListResponseDTO getAllSubGoals(Long userId, Long goalId) {
+        try {
+            if (goalId == null) {
+                throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
+            }
+
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            Goal goal = goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId);
+
+            List<SubGoal> subGoals = subGoalRepositoryFacade.findActiveSubGoalsByGoal(goal);
+            List<SubGoalResponseDTO> subGoalResponseDTOS = subGoalConverter.toSubGoalResponseListDTO(
+                subGoals);
+
+            return SubGoalListResponseDTO
+                .builder()
+                .subGoals(subGoalResponseDTOS)
+                .build();
+        } catch (SubGoalException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("소목표 전체 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_READ_FAILED);
         }
     }
 
@@ -56,17 +156,29 @@ public class SubGoalServiceImpl implements SubGoalService {
 
     @Override
     @Transactional
-    public void deleteSubGoal(Long subGoalId) {
+    public void deleteSubGoal(Long userId, Long goalId, Long subGoalId) {
         try {
             if (subGoalId == null) {
                 throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
             }
+
+            validateSubGoalAccess(userId, goalId, subGoalId);
+
             subGoalRepositoryFacade.deleteActiveSubGoalBySubGoalId(subGoalId);
         } catch (SubGoalException e) {
             throw e;
         } catch (Exception e) {
             log.error("소목표 삭제 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
             throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_DELETE_FAILED);
+        }
+    }
+
+    private void validateSubGoalAccess(Long userId, Long goalId, Long subGoalId) {
+        boolean accessible = subGoalRepositoryFacade.existsValidSubGoal(
+            userId, goalId, subGoalId);
+
+        if (!accessible) {
+            throw new SubGoalException(SubGoalExceptionType.SUB_GOAL_ACCESS_DENIED);
         }
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/PlanController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/PlanController.java
@@ -1,6 +1,5 @@
 package com.hotpack.krocs.domain.plans.controller;
 
-import com.hotpack.krocs.domain.auth.dto.UserSession;
 import com.hotpack.krocs.domain.plans.dto.request.PlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.request.PlanUpdateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.PlanListResponseDTO;
@@ -16,11 +15,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -35,11 +41,10 @@ public class PlanController {
     @Operation(summary = "일정 생성", description = "새로운 일정을 생성합니다.")
     @PostMapping
     public ApiResponse<PlanResponseDTO> createPlan(
-        @Valid @RequestBody PlanCreateRequestDTO requestDTO,
-        @Login UserSession user
+        @Login Long userId,
+        @Valid @RequestBody PlanCreateRequestDTO requestDTO
     ) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             PlanResponseDTO responseDTO = planService.createPlan(requestDTO, userId);
             return ApiResponse.success(responseDTO);
         } catch (PlanException e) {
@@ -52,12 +57,10 @@ public class PlanController {
     @Operation(summary = "범위로 일정 조회", description = "범위로 일정을 조회합니다.")
     @GetMapping
     public ApiResponse<PlanListResponseDTO> getPlans(
-        @Login UserSession user,
+        @Login Long userId,
         @RequestParam(required = false) LocalDate date
     ) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
-
             PlanListResponseDTO response = planService.getPlans(date, userId);
             return ApiResponse.success(response);
         } catch (PlanException e) {
@@ -70,12 +73,11 @@ public class PlanController {
     @Operation(summary = "특정 일정 조회", description = "특정 일정을 조회합니다.")
     @GetMapping("/{planId}")
     public ApiResponse<PlanResponseDTO> getPlanById(
+        @Login Long userId,
         @PathVariable @Parameter(description = "Plan ID", example = "1") @Positive(message = "{common.id.positive}")
-        Long planId,
-        @Login UserSession user
+        Long planId
     ) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             PlanResponseDTO response = planService.getPlanById(planId, userId);
             return ApiResponse.success(response);
         } catch (PlanException e) {
@@ -89,12 +91,11 @@ public class PlanController {
     )
     @PatchMapping("/{planId}")
     public ApiResponse<PlanResponseDTO> updatePlanById(
+        @Login Long userId,
         @PathVariable @Positive(message = "{common.id.positive}") Long planId,
-        @Valid @RequestBody PlanUpdateRequestDTO request,
-        @Login UserSession user) {
+        @Valid @RequestBody PlanUpdateRequestDTO request) {
 
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             PlanResponseDTO responseDTO = planService.updatePlanById(planId, request, userId);
 
             return ApiResponse.success(responseDTO);
@@ -108,11 +109,10 @@ public class PlanController {
     @Operation(summary = "일정 삭제", description = "일정을 삭제합니다")
     @DeleteMapping("/{planId}")
     public ApiResponse<Void> deletePlan(
-        @PathVariable @Positive(message = "{common.id.positive}") @Parameter(description = "Plan ID", example = "1") Long planId,
-        @Login UserSession user
+        @Login Long userId,
+        @PathVariable @Positive(message = "{common.id.positive}") @Parameter(description = "Plan ID", example = "1") Long planId
     ) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             planService.deletePlan(planId, userId);
             return ApiResponse.success();
         } catch (PlanException e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/controller/SubPlanController.java
@@ -5,12 +5,12 @@ import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanUpdateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
-import com.hotpack.krocs.domain.plans.dto.response.SubPlanResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanUpdateResponseDTO;
 import com.hotpack.krocs.domain.plans.exception.SubPlanException;
 import com.hotpack.krocs.domain.plans.exception.SubPlanExceptionType;
 import com.hotpack.krocs.domain.plans.service.SubPlanService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
+import com.hotpack.krocs.global.security.annotation.Login;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/plans")
 @RequiredArgsConstructor
 @Validated
 public class SubPlanController {
@@ -35,13 +35,14 @@ public class SubPlanController {
     private final SubPlanService subPlanService;
 
     @Operation(summary = "소계획 생성", description = "소계획을 생성합니다.")
-    @PostMapping("/plans/{planId}/subplans")
+    @PostMapping("/{planId}/subplans")
     public ApiResponse<SubPlanCreateResponseDTO> createSubPlans(
+        @Login Long userId,
         @PathVariable @Positive(message = "{common.id.positive}") @Parameter(description = "Plan ID", example = "1") Long planId,
         @Valid @RequestBody @Parameter(description = "SubPlans", example = "{\"title\": \"소계획1\"}")
         SubPlanCreateRequestDTO requestDTO) {
         try {
-            SubPlanCreateResponseDTO responseDTO = subPlanService.createSubPlans(planId,
+            SubPlanCreateResponseDTO responseDTO = subPlanService.createSubPlans(planId, userId,
                 requestDTO);
             return ApiResponse.success(responseDTO);
         } catch (SubPlanException e) {
@@ -54,9 +55,10 @@ public class SubPlanController {
     @Operation(summary = "특정 plan 소계획 리스트 조회", description = "특정 plan의 소계획 리스트를 조회합니다.")
     @GetMapping("/{planId}/subplans")
     public ApiResponse<SubPlanListResponseDTO> getSubGoals(
+        @Login Long userId,
         @PathVariable @Positive(message = "{common.id.positive}") @Parameter(description = "Plan ID", example = "1") Long planId) {
         try {
-            SubPlanListResponseDTO response = subPlanService.getAllSubPlans(planId);
+            SubPlanListResponseDTO response = subPlanService.getAllSubPlans(planId, userId);
             return ApiResponse.success(response);
         } catch (SubPlanException e) {
             throw e;
@@ -65,30 +67,17 @@ public class SubPlanController {
         }
     }
 
-    @Operation(summary = "특정 소계획 조회", description = "특정 소계획을 조회합니다")
-    @GetMapping("/{planId}/subplans/{subPlanId}")
-    public ApiResponse<SubPlanResponseDTO> getSubPlan(
-        @PathVariable @Parameter(description = "Plan ID", example = "1") @Positive(message = "{common.id.positive}") Long planId,
-        @PathVariable @Parameter(description = "SubPlan ID", example = "23") @Positive(message = "{common.id.positive}") Long subPlanId) {
-        try {
-            SubPlanResponseDTO response = subPlanService.getSubPlan(planId, subPlanId);
-            return ApiResponse.success(response);
-        } catch (SubPlanException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_READ_FAILED);
-        }
-    }
-
     @Operation(summary = "특정 소계획 수정", description = "특정 소계획을 수정합니다")
-    @PatchMapping("/{subPlanId}")
+    @PatchMapping("/{planId}/subgoals/{subPlanId}")
     public ApiResponse<SubPlanUpdateResponseDTO> updateSubPlan(
+        @Login Long userId,
+        @PathVariable @Parameter(description = "Plan ID", example = "1") @Positive(message = "{common.id.positive}") Long planId,
         @PathVariable @Parameter(description = "SubPlan ID", example = "1") @Positive(message = "{common.id.positive}") Long subPlanId,
         @RequestBody @Parameter(description = "SubPlans", example = "{\"title\": \"소계획1\"}")
         SubPlanUpdateRequestDTO requestDTO) {
         try {
-            SubPlanUpdateResponseDTO responseDTO = subPlanService.updateSubPlan(subPlanId,
-                requestDTO);
+            SubPlanUpdateResponseDTO responseDTO = subPlanService.updateSubPlan(subPlanId, planId,
+                userId, requestDTO);
             return ApiResponse.success(responseDTO);
         } catch (SubPlanException e) {
             throw e;
@@ -99,12 +88,14 @@ public class SubPlanController {
 
 
     @Operation(summary = "특정 소계획 삭제", description = "특정 소계획을 삭제합니다")
-    @DeleteMapping("subplans/{subPlanId}")
+    @DeleteMapping("/{planId}/subplans/{subPlanId}")
     public ApiResponse<Void> deleteSubPlan(
+        @Login Long userId,
+        @PathVariable @Parameter(description = "Plan ID", example = "1") @Positive(message = "{common.id.positive}") Long planId,
         @PathVariable @Parameter(description = "SubPlan ID", example = "1") @Positive(message = "{common.id.positive}") Long subPlanId
     ) {
         try {
-            subPlanService.deleteSubPlan(subPlanId);
+            subPlanService.deleteSubPlan(subPlanId, planId, userId);
             return ApiResponse.success();
         } catch (SubPlanException e) {
             throw e;

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/converter/SubPlanConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/converter/SubPlanConverter.java
@@ -22,7 +22,7 @@ public class SubPlanConverter {
             .build();
     }
 
-    public List<SubPlan> toSubPlanEntityList(Plan plan,
+    public List<SubPlan> toEntityList(Plan plan,
         SubPlanCreateRequestDTO subPlanCreateRequestDTO) {
         return subPlanCreateRequestDTO.getSubPlans().stream()
             .map(subPlanRequestDTO -> toEntity(plan, subPlanRequestDTO))

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/PlanExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/PlanExceptionType.java
@@ -27,7 +27,8 @@ public enum PlanExceptionType implements BaseCode {
     PLAN_END_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN400", "일정 종료시간을 입력해주세요."),
     PLAN_INVALID_ENERGY(HttpStatus.BAD_REQUEST, "PLAN400", "유효하지 않은 에너지 값입니다."),
     PLAN_SUB_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404", "세부일정을 찾을 수 없습니다."),
-    PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "PLAN400", "계획 ID가 null 입니다.");
+    PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "PLAN400", "계획 ID가 null 입니다."),
+    PLAN_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404", "사용자가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -36,21 +37,21 @@ public enum PlanExceptionType implements BaseCode {
     @Override
     public Reason getReason() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
     }
 
     @Override
     public Reason getReasonHttpStatus() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data("")
+            .build();
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/SubPlanExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/SubPlanExceptionType.java
@@ -27,7 +27,7 @@ public enum SubPlanExceptionType implements BaseCode {
     SUB_PLAN_PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBPLAN400", "일정 ID가 null 입니다."),
     SUB_PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획 ID가 null 입니다."),
     SUB_PLAN_NOT_BELONG_TO_PLAN(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획이 해당 일정에 속하지 않습니다."),
-    SUB_PlAN_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBPLAN404", "해당 소계획에 접근할 수 없습니다.");
+    SUB_TEMPLATE_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBPLAN404", "해당 소계획에 접근할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/SubPlanExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/SubPlanExceptionType.java
@@ -27,7 +27,7 @@ public enum SubPlanExceptionType implements BaseCode {
     SUB_PLAN_PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBPLAN400", "일정 ID가 null 입니다."),
     SUB_PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획 ID가 null 입니다."),
     SUB_PLAN_NOT_BELONG_TO_PLAN(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획이 해당 일정에 속하지 않습니다."),
-    SUB_TEMPLATE_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBPLAN404", "해당 소계획에 접근할 수 없습니다.");
+    SUB_PLAN_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBPLAN404", "해당 소계획에 접근할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/SubPlanExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/exception/SubPlanExceptionType.java
@@ -26,7 +26,8 @@ public enum SubPlanExceptionType implements BaseCode {
     SUB_PLAN_CREATE_EMPTY(HttpStatus.BAD_REQUEST, "SUBPLAN400", "생성할 소계획이 없습니다."),
     SUB_PLAN_PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBPLAN400", "일정 ID가 null 입니다."),
     SUB_PLAN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획 ID가 null 입니다."),
-    SUB_PLAN_NOT_BELONG_TO_PLAN(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획이 해당 일정에 속하지 않습니다.");
+    SUB_PLAN_NOT_BELONG_TO_PLAN(HttpStatus.BAD_REQUEST, "SUBPLAN400", "소계획이 해당 일정에 속하지 않습니다."),
+    SUB_PlAN_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBPLAN404", "해당 소계획에 접근할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/facade/PlanRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/facade/PlanRepositoryFacade.java
@@ -3,8 +3,6 @@ package com.hotpack.krocs.domain.plans.facade;
 import com.hotpack.krocs.domain.plans.domain.Plan;
 import com.hotpack.krocs.domain.plans.exception.PlanException;
 import com.hotpack.krocs.domain.plans.exception.PlanExceptionType;
-import com.hotpack.krocs.domain.plans.exception.SubPlanException;
-import com.hotpack.krocs.domain.plans.exception.SubPlanExceptionType;
 import com.hotpack.krocs.domain.plans.repository.PlanRepository;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.time.LocalDateTime;
@@ -27,15 +25,11 @@ public class PlanRepositoryFacade {
         return planRepository.save(plan);
     }
 
-    public Plan findActivePlanById(Long id) {
-        Plan plan = planRepository.findPlanByPlanIdAndStatus(id, Status.ACTIVE);
-        if (plan == null) {
-            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_NOT_FOUND);
-        }
-
-        return plan;
+    public Plan findActivePlanByPlanIdAndUserId(Long planId, Long userId) {
+        return planRepository.findPlanByIdAndUserIdAndStatus(planId, userId,
+            Status.ACTIVE);
     }
-    
+
     public List<Plan> findActivePlansByDateRange(LocalDateTime startOfDay, LocalDateTime endOfDay,
         Long userId) {
         return planRepository.findPlansByDateRangeAndStatus(startOfDay, endOfDay, userId,
@@ -43,8 +37,8 @@ public class PlanRepositoryFacade {
     }
 
     @Transactional
-    public void deleteActivePlanByPlanId(Long planId) {
-        Plan plan = findActivePlanById(planId);
+    public void deleteActivePlanByPlanId(Long planId, Long userId) {
+        Plan plan = findActivePlanByPlanIdAndUserId(planId, userId);
         if (plan == null) {
             throw new PlanException(PlanExceptionType.PLAN_NOT_FOUND);
         }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/facade/SubPlanRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/facade/SubPlanRepositoryFacade.java
@@ -32,9 +32,6 @@ public class SubPlanRepositoryFacade {
     public SubPlan findActiveSubPlanBySubPlanId(Long subPlanId) {
         SubPlan subPlan = subPlanRepository.findSubPlansBySubPlanIdAndStatus(subPlanId,
             Status.ACTIVE);
-        if (subPlan == null) {
-            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_NOT_FOUND);
-        }
         return subPlan;
     }
 
@@ -48,5 +45,8 @@ public class SubPlanRepositoryFacade {
         subPlan.delete();
     }
 
+    public boolean existsValidSubPlan(Long userId, Long planId, Long subPlanId) {
+        return subPlanRepository.existsValidSubPlan(userId, planId, subPlanId, Status.ACTIVE);
+    }
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/repository/PlanRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/repository/PlanRepository.java
@@ -20,5 +20,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
         @Param("status") Status status
     );
 
-    Plan findPlanByPlanIdAndStatus(Long id, Status status);
+    @Query("SELECT p FROM Plan p WHERE p.user.userId = :userId AND p.planId = :planId AND p.status = :status")
+    Plan findPlanByIdAndUserIdAndStatus(@Param("planId") Long planId, @Param("userId") Long userId,
+        @Param("status") Status status);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/repository/SubPlanRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/repository/SubPlanRepository.java
@@ -5,11 +5,31 @@ import com.hotpack.krocs.domain.plans.domain.SubPlan;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubPlanRepository extends JpaRepository<SubPlan, Long> {
 
     List<SubPlan> findSubPlansByPlanAndStatus(Plan plan, Status status);
 
     SubPlan findSubPlansBySubPlanIdAndStatus(Long subPlanId, Status status);
-    
+
+    @Query(value = """
+        SELECT EXISTS (
+            SELECT 1
+            FROM sub_plans s
+            JOIN plans p ON s.plan_id = p.plan_id
+            JOIN users u ON p.user_id = u.user_id
+            WHERE s.sub_plan_id = :subPlanId
+              AND p.goal_id = :planId
+              AND u.user_id = :userId
+              AND s.status = :status
+        )
+        """, nativeQuery = true)
+    boolean existsValidSubPlan(
+        @Param("userId") Long userId,
+        @Param("planId") Long planId,
+        @Param("subPlanId") Long subPlanId,
+        @Param("status") Status status);
+
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/PlanServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/PlanServiceImpl.java
@@ -1,7 +1,5 @@
 package com.hotpack.krocs.domain.plans.service;
 
-import com.hotpack.krocs.domain.goals.domain.Goal;
-import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
 import com.hotpack.krocs.domain.plans.converter.PlanConverter;
 import com.hotpack.krocs.domain.plans.domain.Plan;
@@ -14,6 +12,7 @@ import com.hotpack.krocs.domain.plans.exception.PlanExceptionType;
 import com.hotpack.krocs.domain.plans.facade.PlanRepositoryFacade;
 import com.hotpack.krocs.domain.plans.validator.PlanValidator;
 import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -30,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlanServiceImpl implements PlanService {
 
     private final PlanRepositoryFacade planRepositoryFacade;
+    private final UserRepositoryFacade userRepositoryFacade;
     private final PlanConverter planConverter;
     private final SubGoalRepositoryFacade subGoalRepositoryFacade;
     private final PlanValidator planValidator;
@@ -39,16 +39,12 @@ public class PlanServiceImpl implements PlanService {
     public PlanResponseDTO createPlan(PlanCreateRequestDTO requestDTO, Long userId) {
         try {
             planValidator.validatePlanCreation(requestDTO);
-
-            Plan plan;
-            if (userId != null) {
-                User userRef = User.builder()
-                    .userId(userId)
-                    .build();
-                plan = planConverter.toEntity(requestDTO, userRef);
-            } else {
-                plan = planConverter.toEntity(requestDTO);
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new PlanException(PlanExceptionType.PLAN_USER_NOT_FOUND);
             }
+
+            Plan plan = planConverter.toEntity(requestDTO, user);
             Plan savedPlan = planRepositoryFacade.savePlan(plan);
 
             return planConverter.toEntity(savedPlan);
@@ -89,7 +85,7 @@ public class PlanServiceImpl implements PlanService {
     public PlanResponseDTO getPlanById(Long planId, Long userId) {
         try {
             planValidator.validateGetPlan(planId);
-            Plan plan = planRepositoryFacade.findActivePlanById(planId);
+            Plan plan = planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId);
             if (plan == null) {
                 throw new PlanException(PlanExceptionType.PLAN_NOT_FOUND);
             }
@@ -109,7 +105,7 @@ public class PlanServiceImpl implements PlanService {
         try {
             planValidator.validateUpdatePlan(planId);
 
-            Plan plan = planRepositoryFacade.findActivePlanById(planId);
+            Plan plan = planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId);
             if (plan == null) {
                 throw new PlanException(PlanExceptionType.PLAN_NOT_FOUND);
             }
@@ -168,11 +164,11 @@ public class PlanServiceImpl implements PlanService {
     public void deletePlan(Long planId, Long userId) {
         try {
             planValidator.validateDeletePlan(planId);
-            if (planRepositoryFacade.findActivePlanById(planId) == null) {
+            if (planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId) == null) {
                 throw new PlanException(PlanExceptionType.PLAN_NOT_FOUND);
             }
 
-            planRepositoryFacade.deleteActivePlanByPlanId(planId);
+            planRepositoryFacade.deleteActivePlanByPlanId(planId, userId);
         } catch (PlanException e) {
             throw e;
         } catch (Exception e) {
@@ -180,4 +176,5 @@ public class PlanServiceImpl implements PlanService {
             throw new PlanException(PlanExceptionType.PLAN_DELETE_FAILED);
         }
     }
+
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanService.java
@@ -1,26 +1,22 @@
 package com.hotpack.krocs.domain.plans.service;
 
 
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanCreateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.request.SubPlanUpdateRequestDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanCreateResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanListResponseDTO;
-import com.hotpack.krocs.domain.plans.dto.response.SubPlanResponseDTO;
 import com.hotpack.krocs.domain.plans.dto.response.SubPlanUpdateResponseDTO;
-import org.springframework.stereotype.Service;
 
 public interface SubPlanService {
 
-    SubPlanCreateResponseDTO createSubPlans(Long planId,
+    SubPlanCreateResponseDTO createSubPlans(Long planId, Long userId,
         SubPlanCreateRequestDTO subPlanCreateRequestDTO);
 
-    SubPlanListResponseDTO getAllSubPlans(Long planId);
+    SubPlanListResponseDTO getAllSubPlans(Long planId, Long userId);
 
-    SubPlanResponseDTO getSubPlan(Long planId, Long subPlanId);
+    SubPlanUpdateResponseDTO updateSubPlan(Long subPlanId, Long planId, Long userId,
+        SubPlanUpdateRequestDTO requestDTO);
 
-    SubPlanUpdateResponseDTO updateSubPlan(Long subPlanId, SubPlanUpdateRequestDTO requestDTO);
-
-    void deleteSubPlan(Long subPlanId);
+    void deleteSubPlan(Long subPlanId, Long planId, Long userId);
 }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
@@ -166,7 +166,7 @@ public class SubPlanServiceImpl implements SubPlanService {
         boolean accessible = subPlanRepositoryFacade.existsValidSubPlan(userId, planId, subPlanId);
 
         if (!accessible) {
-            throw new SubPlanException(SubPlanExceptionType.SUB_PlAN_ACCESS_DENIED);
+            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_ACCESS_DENIED);
         }
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceImpl.java
@@ -34,7 +34,7 @@ public class SubPlanServiceImpl implements SubPlanService {
 
     @Override
     @Transactional
-    public SubPlanCreateResponseDTO createSubPlans(Long planId,
+    public SubPlanCreateResponseDTO createSubPlans(Long planId, Long userId,
         SubPlanCreateRequestDTO requestDTO) {
         try {
             if (planId == null) {
@@ -42,9 +42,12 @@ public class SubPlanServiceImpl implements SubPlanService {
             }
             validateSubPlanCreation(requestDTO);
 
-            Plan plan = planRepositoryFacade.findActivePlanById(planId);
+            Plan plan = planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId);
+            if (plan == null) {
+                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_NOT_FOUND);
+            }
 
-            List<SubPlan> subPlans = subPlanConverter.toSubPlanEntityList(plan, requestDTO);
+            List<SubPlan> subPlans = subPlanConverter.toEntityList(plan, requestDTO);
             List<SubPlan> createdSubPlans = subPlanRepositoryFacade.saveSubPlans(subPlans);
             List<SubPlanResponseDTO> subPlanResponseDTOs = subPlanConverter.toSubPlanResponseListDTO(
                 createdSubPlans);
@@ -78,13 +81,16 @@ public class SubPlanServiceImpl implements SubPlanService {
     }
 
     @Override
-    public SubPlanListResponseDTO getAllSubPlans(Long planId) {
+    public SubPlanListResponseDTO getAllSubPlans(Long planId, Long userId) {
         try {
             if (planId == null) {
                 throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
             }
 
-            Plan plan = planRepositoryFacade.findActivePlanById(planId);
+            Plan plan = planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId);
+            if (plan == null) {
+                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_NOT_FOUND);
+            }
 
             List<SubPlan> subPlans = subPlanRepositoryFacade.findActiveSubPlansByPlan(plan);
             List<SubPlanResponseDTO> subPlanResponseDTOs = subPlanConverter.toSubPlanResponseListDTO(
@@ -102,42 +108,15 @@ public class SubPlanServiceImpl implements SubPlanService {
     }
 
     @Override
-    public SubPlanResponseDTO getSubPlan(Long planId, Long subPlanId) {
-        try {
-            if (planId == null) {
-                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
-            }
-            if (subPlanId == null) {
-                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
-            }
-
-            Plan plan = planRepositoryFacade.findActivePlanById(planId);
-            List<SubPlan> subPlans = subPlanRepositoryFacade.findActiveSubPlansByPlan(plan);
-            SubPlan subPlan = subPlanRepositoryFacade.findActiveSubPlanBySubPlanId(subPlanId);
-
-            if (!subPlans.contains(subPlan)) {
-                throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_NOT_BELONG_TO_PLAN);
-            }
-
-            return subPlanConverter.toSubPlanResponseDTO(subPlan);
-
-        } catch (SubPlanException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("소계획 단건 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
-            throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_READ_FAILED);
-        }
-    }
-
-    @Override
     @Transactional
-    public SubPlanUpdateResponseDTO updateSubPlan(Long subPlanId,
+    public SubPlanUpdateResponseDTO updateSubPlan(Long subPlanId, Long planId, Long userId,
         SubPlanUpdateRequestDTO requestDTO) {
         try {
             if (subPlanId == null) {
                 throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
             }
 
+            validateSubPlanAccess(userId, planId, subPlanId);
             validateBusinessRules(requestDTO);
 
             SubPlan subPlan = subPlanRepositoryFacade.findActiveSubPlanBySubPlanId(subPlanId);
@@ -167,17 +146,27 @@ public class SubPlanServiceImpl implements SubPlanService {
 
     @Override
     @Transactional
-    public void deleteSubPlan(Long subPlanId) {
+    public void deleteSubPlan(Long subPlanId, Long planId, Long userId) {
         try {
             if (subPlanId == null) {
                 throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
             }
+            validateSubPlanAccess(userId, planId, subPlanId);
+
             subPlanRepositoryFacade.deleteActiveSubPlanBySubPlanId(subPlanId);
         } catch (SubPlanException e) {
             throw e;
         } catch (Exception e) {
             log.error("소계획 삭제 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
             throw new SubPlanException(SubPlanExceptionType.SUB_PLAN_DELETE_FAILED);
+        }
+    }
+
+    private void validateSubPlanAccess(Long userId, Long planId, Long subPlanId) {
+        boolean accessible = subPlanRepositoryFacade.existsValidSubPlan(userId, planId, subPlanId);
+
+        if (!accessible) {
+            throw new SubPlanException(SubPlanExceptionType.SUB_PlAN_ACCESS_DENIED);
         }
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/SubTemplateController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/SubTemplateController.java
@@ -1,20 +1,27 @@
 package com.hotpack.krocs.domain.templates.controller;
 
+import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.request.SubTemplateUpdateRequestDTO;
+import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.SubTemplateDeleteResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
 import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
 import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
 import com.hotpack.krocs.domain.templates.service.SubTemplateService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
+import com.hotpack.krocs.global.security.annotation.Login;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,19 +29,57 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/subtemplates")
+@RequestMapping("/api/v1/templates")
 @Validated
 public class SubTemplateController {
 
     private final SubTemplateService subTemplateService;
 
+    @Operation(summary = "서브 템플릿 생성", description = "템플릿에 종속된 서브 템플릿을 생성합니다.")
+    @PostMapping("/{templateId}/subtemplates")
+    public ApiResponse<SubTemplateCreateResponseDTO> saveSubTemplates(
+        @Login Long userId,
+        @Valid @RequestBody SubTemplateCreateRequestDTO requestDTO,
+        @PathVariable(value = "templateId") @Positive(message = "{common.id.positive}") Long templateId
+    ) {
+        try {
+            SubTemplateCreateResponseDTO responseDTO = subTemplateService.createSubTemplates(
+                templateId, requestDTO, userId);
+            return ApiResponse.success(responseDTO);
+        } catch (SubTemplateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
+        }
+    }
+
+    @Operation(summary = "서브 템플릿 전체 조회", description = "템플릿에 종속된 모든 서브 템플릿을 조회합니다.")
+    @GetMapping("/{templateId}/subtemplates")
+    public ApiResponse<List<SubTemplateResponseDTO>> getSubTemplates(
+        @Login Long userId,
+        @PathVariable(value = "templateId") @Positive(message = "{common.id.positive}") Long templateId
+    ) {
+        try {
+            List<SubTemplateResponseDTO> responseDTOs = subTemplateService.getSubTemplates(
+                templateId, userId);
+            return ApiResponse.success(responseDTOs);
+        } catch (SubTemplateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_FOUND_FAILED);
+        }
+    }
+
+
     @Operation(summary = "서브 템플릿 삭제", description = "subTemplateId를 조회하여 서브템플릿을 삭제합니다.")
-    @DeleteMapping("/{subTemplateId}")
+    @DeleteMapping("{templateId}/subtemplates/{subTemplateId}")
     public ApiResponse<SubTemplateDeleteResponseDTO> deleteSubTemplate(
+        @Login Long userId,
+        @PathVariable("templateId") @Positive(message = "{common.id.positive}") Long templateId,
         @PathVariable("subTemplateId") @Positive(message = "{common.id.positive}") Long subTemplateId) {
         try {
             SubTemplateDeleteResponseDTO responseDTO = subTemplateService.deleteSubTemplate(
-                subTemplateId);
+                subTemplateId, templateId, userId);
 
             return ApiResponse.success(responseDTO);
         } catch (SubTemplateException e) {
@@ -45,14 +90,16 @@ public class SubTemplateController {
     }
 
     @Operation(summary = "서브 템플릿 수정", description = "subTemplateId를 조회하여 서브템플릿을 수정합니다.")
-    @PatchMapping("/{subTemplateId}")
+    @PatchMapping("{templateId}/subtemplates/{subTemplateId}")
     public ApiResponse<SubTemplateResponseDTO> updateSubTemplate(
+        @Login Long userId,
+        @PathVariable("templateId") @Positive(message = "{common.id.positive}") Long templateId,
         @PathVariable("subTemplateId") @Positive(message = "{common.id.positive}") Long subTemplateId,
         @RequestBody SubTemplateUpdateRequestDTO request
     ) {
         try {
             SubTemplateResponseDTO responseDTO = subTemplateService.updateSubTemplate(subTemplateId,
-                request);
+                templateId, userId, request);
             return ApiResponse.success(responseDTO);
         } catch (SubTemplateException e) {
             throw e;
@@ -60,6 +107,4 @@ public class SubTemplateController {
             throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_UPDATE_FAILED);
         }
     }
-
-
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
@@ -1,19 +1,12 @@
 package com.hotpack.krocs.domain.templates.controller;
 
 
-import com.hotpack.krocs.domain.auth.dto.UserSession;
-import com.hotpack.krocs.domain.templates.dto.request.SubTemplateCreateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateCreateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.request.TemplateUpdateRequestDTO;
-import com.hotpack.krocs.domain.templates.dto.response.SubTemplateCreateResponseDTO;
-import com.hotpack.krocs.domain.templates.dto.response.SubTemplateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateResponseDTO;
-import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
-import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
 import com.hotpack.krocs.domain.templates.exception.TemplateException;
 import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
-import com.hotpack.krocs.domain.templates.service.SubTemplateService;
 import com.hotpack.krocs.domain.templates.service.TemplateService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
 import com.hotpack.krocs.global.security.annotation.Login;
@@ -43,16 +36,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class TemplateController {
 
     private final TemplateService templateService;
-    private final SubTemplateService subTemplateService;
 
     @Operation(summary = "템플릿 생성", description = "title, priority을 설정해 템플릿을 생성합니다.")
     @PostMapping
     public ApiResponse<TemplateCreateResponseDTO> createTemplate(
-        @Valid @RequestBody TemplateCreateRequestDTO requestDTO,
-        @Login UserSession user
+        @Login Long userId,
+        @Valid @RequestBody TemplateCreateRequestDTO requestDTO
     ) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             TemplateCreateResponseDTO responseDTO = templateService.createTemplate(requestDTO,
                 userId);
             return ApiResponse.success(responseDTO);
@@ -68,13 +59,11 @@ public class TemplateController {
     @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
     @GetMapping
     public ApiResponse<List<TemplateResponseDTO>> getTemplates(
-        @Login UserSession user,
+        @Login Long userId,
         @RequestParam(required = false) String title) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             List<TemplateResponseDTO> responseDTO = templateService.getTemplatesByUserAndTitle(
-                userId,
-                title);
+                userId, title);
             return ApiResponse.success(responseDTO);
 
         } catch (TemplateException e) {
@@ -89,11 +78,10 @@ public class TemplateController {
     @Operation(summary = "템플릿 수정", description = "탬플릿을 id 기준으로 수정합니다.")
     @PatchMapping("/{template_id}")
     public ApiResponse<TemplateResponseDTO> updateTemplates(
+        @Login Long userId,
         @PathVariable(value = "template_id") @Positive(message = "{common.id.positive}") Long templateId,
-        @Login UserSession user,
         @RequestBody TemplateUpdateRequestDTO requestDTO) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             TemplateResponseDTO responseDTO = templateService.updateTemplate(templateId, userId,
                 requestDTO);
             return ApiResponse.success(responseDTO);
@@ -109,10 +97,9 @@ public class TemplateController {
     @Operation(summary = "템플릿 삭제", description = "템플릿을 탬플릿ID로 삭제합니다.")
     @DeleteMapping("/{template_id}")
     public ApiResponse<Void> deleteTemplate(
-        @PathVariable(value = "template_id") @Positive(message = "{common.id.positive}") Long templateId,
-        @Login UserSession user) {
+        @Login Long userId,
+        @PathVariable(value = "template_id") @Positive(message = "{common.id.positive}") Long templateId) {
         try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
             templateService.deleteTemplate(templateId, userId);
             return ApiResponse.success(null);
 
@@ -121,45 +108,6 @@ public class TemplateController {
 
         } catch (Exception e) {
             throw new TemplateException(TemplateExceptionType.TEMPLATE_DELETE_FAILED);
-        }
-    }
-
-    //============== SubTemplate ==============
-
-    @Operation(summary = "서브 템플릿 생성", description = "템플릿에 종속된 서브 템플릿을 생성합니다.")
-    @PostMapping("/{templateId}/subtemplates")
-    public ApiResponse<SubTemplateCreateResponseDTO> saveSubTemplates(
-        @Valid @RequestBody SubTemplateCreateRequestDTO requestDTO,
-        @PathVariable(value = "templateId") @Positive(message = "{common.id.positive}") Long templateId,
-        @Login UserSession user
-    ) {
-        try {
-            Long userId = user != null ? Long.valueOf(user.getUserId()) : null;
-            SubTemplateCreateResponseDTO responseDTO = subTemplateService.createSubTemplates(
-                templateId,
-                requestDTO, userId);
-            return ApiResponse.success(responseDTO);
-        } catch (SubTemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_CREATION_FAILED);
-        }
-    }
-
-    @Operation(summary = "서브 템플릿 전체 조회", description = "템플릿에 종속된 모든 서브 템플릿을 조회합니다.")
-    @GetMapping("/{templateId}/subtemplates")
-    public ApiResponse<List<SubTemplateResponseDTO>> getSubTemplates(
-        @PathVariable(value = "templateId") @Positive(message = "{common.id.positive}") Long templateId,
-        @Login UserSession user
-    ) {
-        try {
-            List<SubTemplateResponseDTO> responseDTOs = subTemplateService.getSubTemplates(
-                templateId);
-            return ApiResponse.success(responseDTOs);
-        } catch (SubTemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_FOUND_FAILED);
         }
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/SubTemplateExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/SubTemplateExceptionType.java
@@ -24,9 +24,10 @@ public enum SubTemplateExceptionType implements BaseCode {
     SUB_TEMPLATE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SUBTEMPLATE500",
         "서브 탬플릿 삭제에 실패했습니다."),
     SUB_TEMPLATE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "SUBTEMPLATE400", "서브 탬플릿 제목이 너무 깁니다."),
-    SUB_TEMPLATE_SUB_TEMPLATE_ID_IS_NULL(HttpStatus.BAD_REQUEST,
-        "SUBTEMPLATE400",
-        "서브 템플릿 아이디가 null 입니다.");
+    SUB_TEMPLATE_SUB_TEMPLATE_ID_IS_NULL(HttpStatus.BAD_REQUEST, "SUBTEMPLATE400",
+        "서브 템플릿 아이디가 null 입니다."),
+    SUB_TEMPLATE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBTEMPLATE404", "사용자가 존재하지 않습니다."),
+    SUB_TEMPLATE_ACCESS_DENIED(HttpStatus.NOT_FOUND, "SUBTEMPLATE404", "해당 소계획에 접근할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/TemplateExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/exception/TemplateExceptionType.java
@@ -1,16 +1,10 @@
 package com.hotpack.krocs.domain.templates.exception;
 
-import com.hotpack.krocs.domain.templates.domain.Template;
-import com.hotpack.krocs.domain.templates.repository.TemplateRepository;
 import com.hotpack.krocs.global.common.response.code.BaseCode;
 import com.hotpack.krocs.global.common.response.code.Reason;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 
 @Getter
@@ -24,7 +18,8 @@ public enum TemplateExceptionType implements BaseCode {
     TEMPLATE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEMPLATE500", "탬플릿 수정에 실패했습니다."),
     TEMPLATE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEMPLATE500", "탬플릿 삭제에 실패했습니다."),
     TEMPLATE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "TEMPLATE400", "탬플릿 제목이 너무 깁니다."),
-    TEMPLATE_INVALID_PRIORITY(HttpStatus.BAD_REQUEST, "TEMPLATE400", "유효하지 않은 우선순위입니다.");
+    TEMPLATE_INVALID_PRIORITY(HttpStatus.BAD_REQUEST, "TEMPLATE400", "유효하지 않은 우선순위입니다."),
+    TEMPLATE_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMPLATE404", "사용자가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -33,21 +28,21 @@ public enum TemplateExceptionType implements BaseCode {
     @Override
     public Reason getReason() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
     }
 
     @Override
     public Reason getReasonHttpStatus() {
         return Reason.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .data("")
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data("")
+            .build();
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/SubTemplateRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/SubTemplateRepositoryFacade.java
@@ -56,4 +56,9 @@ public class SubTemplateRepositoryFacade {
 
         return subTemplate;
     }
+
+    public boolean existsValidSubTemplate(Long userId, Long subTemplateId, Long templateId) {
+        return subTemplateRepository.existsValidSubTemplate(userId, subTemplateId, templateId,
+            Status.ACTIVE);
+    }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
@@ -1,8 +1,6 @@
 package com.hotpack.krocs.domain.templates.facade;
 
 import com.hotpack.krocs.domain.templates.domain.Template;
-import com.hotpack.krocs.domain.templates.exception.TemplateException;
-import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.repository.TemplateRepository;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
@@ -40,12 +38,8 @@ public class TemplateRepositoryFacade {
     }
 
     public Template findActiveParentTemplateByTemplateIdAndUserId(Long templateId, Long userId) {
-        Template template = templateRepository.findTemplateByTemplateIdAndUser_UserIdAndStatus(
+        return templateRepository.findTemplateByTemplateIdAndUser_UserIdAndStatus(
             templateId, userId, Status.ACTIVE);
-        if (template == null) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND);
-        }
-        return template;
     }
 
     @Transactional

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
@@ -1,8 +1,6 @@
 package com.hotpack.krocs.domain.templates.facade;
 
 import com.hotpack.krocs.domain.templates.domain.Template;
-import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
-import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
 import com.hotpack.krocs.domain.templates.exception.TemplateException;
 import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.repository.TemplateRepository;
@@ -27,29 +25,25 @@ public class TemplateRepositoryFacade {
         return templateRepository.save(template);
     }
 
-    public List<Template> findActiveTemplatesByTitle(String title) {
-        return templateRepository.findTemplatesByTitleContainingIgnoreCaseAndStatus(title,
-            Status.ACTIVE);
+    public List<Template> findActiveTemplatesByTitleAndUserId(String title, Long userId) {
+        return templateRepository.findTemplatesByTitleContainingIgnoreCaseAndUser_userIdAndStatus(
+            title, userId, Status.ACTIVE);
     }
 
-    public List<Template> findAllActiveTemplates() {
-        return templateRepository.findAllTemplatesByStatus(Status.ACTIVE);
+    public List<Template> findAllActiveTemplatesAndUserId(Long userId) {
+        return templateRepository.findAllTemplatesByUser_UserIdAndStatus(userId, Status.ACTIVE);
     }
 
-    public Template findActiveTemplateByTemplateId(Long templateId) {
-        Template template = templateRepository.findTemplateByTemplateIdAndStatus(templateId,
-            Status.ACTIVE);
-        if(template == null){
+    public Template findActiveTemplateByTemplateIdAndUserId(Long templateId, Long userId) {
+        return templateRepository.findTemplateByTemplateIdAndUser_UserIdAndStatus(templateId,
+            userId, Status.ACTIVE);
+    }
+
+    public Template findActiveParentTemplateByTemplateIdAndUserId(Long templateId, Long userId) {
+        Template template = templateRepository.findTemplateByTemplateIdAndUser_UserIdAndStatus(
+            templateId, userId, Status.ACTIVE);
+        if (template == null) {
             throw new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND);
-        }
-        return template;
-    }
-
-    public Template findActiveParentTemplateByTemplateId(Long templateId) {
-        Template template = templateRepository.findTemplateByTemplateIdAndStatus(templateId,
-            Status.ACTIVE);
-        if(template == null){
-            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOT_FOUND);
         }
         return template;
     }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/SubTemplateRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/SubTemplateRepository.java
@@ -5,6 +5,8 @@ import com.hotpack.krocs.domain.templates.domain.Template;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +15,22 @@ public interface SubTemplateRepository extends JpaRepository<SubTemplate, Long> 
     List<SubTemplate> findSubTemplatesByTemplateAndStatus(Template template, Status status);
 
     SubTemplate findSubTemplateBySubTemplateIdAndStatus(Long subTemplateId, Status status);
+
+    @Query(value = """
+        SELECT EXISTS (
+            SELECT 1
+            FROM sub_templates s
+            JOIN templates t ON s.template_id = t.template_id
+            JOIN users u ON t.user_id = u.user_id
+            WHERE s.sub_template_id = :subTemplateId
+              AND t.template_id = :templateId
+              AND u.user_id = :userId
+              AND s.status = :status
+        )
+        """, nativeQuery = true)
+    boolean existsValidSubTemplate(
+        @Param("userId") Long userId,
+        @Param("templateId") Long templateId,
+        @Param("subTemplateId") Long subTemplateId,
+        @Param("status") Status status);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/TemplateRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/TemplateRepository.java
@@ -9,10 +9,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TemplateRepository extends JpaRepository<Template, Long> {
 
-    List<Template> findTemplatesByTitleContainingIgnoreCaseAndStatus(String title, Status status);
+    List<Template> findTemplatesByTitleContainingIgnoreCaseAndUser_userIdAndStatus(String title,
+        Long userId, Status status);
 
-    List<Template> findAllTemplatesByStatus(Status status);
+    List<Template> findAllTemplatesByUser_UserIdAndStatus(Long userId, Status status);
 
-    Template findTemplateByTemplateIdAndStatus(Long templateId, Status status);
+    Template findTemplateByTemplateIdAndUser_UserIdAndStatus(Long templateId, Long userId,
+        Status status);
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateService.java
@@ -10,13 +10,13 @@ import java.util.List;
 public interface SubTemplateService {
 
     SubTemplateCreateResponseDTO createSubTemplates(Long templateId,
-        SubTemplateCreateRequestDTO requestDTO,
+        SubTemplateCreateRequestDTO requestDTO, Long userId);
+
+    List<SubTemplateResponseDTO> getSubTemplates(Long templateId, Long userId);
+
+    SubTemplateDeleteResponseDTO deleteSubTemplate(Long subTemplateId, Long templateId,
         Long userId);
 
-    List<SubTemplateResponseDTO> getSubTemplates(Long templateId);
-
-    SubTemplateDeleteResponseDTO deleteSubTemplate(Long subTemplateId);
-
-    SubTemplateResponseDTO updateSubTemplate(Long subTemplateId,
+    SubTemplateResponseDTO updateSubTemplate(Long subTemplateId, Long templateId, Long userId,
         SubTemplateUpdateRequestDTO requestDTO);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceImpl.java
@@ -1,5 +1,6 @@
 package com.hotpack.krocs.domain.templates.service;
 
+import com.hotpack.krocs.domain.plans.facade.SubPlanRepositoryFacade;
 import com.hotpack.krocs.domain.templates.converter.SubTemplateConverter;
 import com.hotpack.krocs.domain.templates.domain.SubTemplate;
 import com.hotpack.krocs.domain.templates.domain.Template;
@@ -12,6 +13,8 @@ import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
 import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
 import com.hotpack.krocs.domain.templates.facade.SubTemplateRepositoryFacade;
 import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
+import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,9 +27,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubTemplateServiceImpl implements SubTemplateService {
 
     private final TemplateRepositoryFacade templateRepositoryFacade;
+    private final UserRepositoryFacade userRepositoryFacade;
     private final SubTemplateRepositoryFacade subTemplateRepositoryFacade;
 
     private final SubTemplateConverter subTemplateConverter;
+    private final SubPlanRepositoryFacade subPlanRepositoryFacade;
 
     @Override
     @Transactional
@@ -38,12 +43,25 @@ public class SubTemplateServiceImpl implements SubTemplateService {
                 throw new SubTemplateException(
                     SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_ID_IS_NULL);
             }
-            Template template = templateRepositoryFacade.findActiveParentTemplateByTemplateId(
-                templateId);
+
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new SubTemplateException(
+                    SubTemplateExceptionType.SUB_TEMPLATE_USER_NOT_FOUND);
+            }
+
+            Template template = templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(
+                templateId, userId);
+            if (template == null) {
+                throw new SubTemplateException(
+                    SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOT_FOUND);
+            }
+
             List<SubTemplate> subTemplates = subTemplateConverter.toEntityList(template,
                 requestDTO);
             List<SubTemplate> createdSubTemplates = subTemplateRepositoryFacade.saveAll(
                 subTemplates);
+
             return subTemplateConverter.toCreateResponseDTO(createdSubTemplates);
 
         } catch (SubTemplateException e) {
@@ -55,15 +73,19 @@ public class SubTemplateServiceImpl implements SubTemplateService {
     }
 
     @Override
-    public List<SubTemplateResponseDTO> getSubTemplates(Long templateId) {
+    public List<SubTemplateResponseDTO> getSubTemplates(Long templateId, Long userId) {
         try {
             if (templateId == null) {
                 throw new SubTemplateException(
                     SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_ID_IS_NULL);
             }
 
-            Template template = templateRepositoryFacade.findActiveParentTemplateByTemplateId(
-                templateId);
+            Template template = templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(
+                templateId, userId);
+            if (template == null) {
+                throw new SubTemplateException(
+                    SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOT_FOUND);
+            }
 
             List<SubTemplate> subTemplates = subTemplateRepositoryFacade.findActiveSubTemplatesByTemplate(
                 template);
@@ -79,12 +101,14 @@ public class SubTemplateServiceImpl implements SubTemplateService {
 
     @Override
     @Transactional
-    public SubTemplateDeleteResponseDTO deleteSubTemplate(Long subTemplateId) {
+    public SubTemplateDeleteResponseDTO deleteSubTemplate(Long subTemplateId, Long templateId,
+        Long userId) {
         try {
             if (subTemplateId == null) {
                 throw new SubTemplateException(
                     SubTemplateExceptionType.SUB_TEMPLATE_SUB_TEMPLATE_ID_IS_NULL);
             }
+            validateSubTemplateAccess(userId, templateId, subTemplateId);
 
             Long deletedSubTemplateId = subTemplateRepositoryFacade.deleteActiveSubTemplateBySubTemplateId(
                 subTemplateId);
@@ -92,6 +116,7 @@ public class SubTemplateServiceImpl implements SubTemplateService {
             return SubTemplateDeleteResponseDTO.builder()
                 .subTemplateId(deletedSubTemplateId)
                 .build();
+
         } catch (SubTemplateException e) {
             throw e;
         } catch (Exception e) {
@@ -102,13 +127,15 @@ public class SubTemplateServiceImpl implements SubTemplateService {
 
     @Override
     @Transactional
-    public SubTemplateResponseDTO updateSubTemplate(Long subTemplateId,
-        SubTemplateUpdateRequestDTO requestDTO) {
+    public SubTemplateResponseDTO updateSubTemplate(Long subTemplateId, Long templateId,
+        Long userId, SubTemplateUpdateRequestDTO requestDTO) {
         try {
             if (subTemplateId == null) {
                 throw new SubTemplateException(
                     SubTemplateExceptionType.SUB_TEMPLATE_SUB_TEMPLATE_ID_IS_NULL);
             }
+
+            validateSubTemplateAccess(userId, templateId, subTemplateId);
 
             SubTemplate updatedSubTemplate = subTemplateRepositoryFacade.updateActiveSubTemplateBySubTemplateId(
                 subTemplateId, requestDTO);
@@ -119,6 +146,15 @@ public class SubTemplateServiceImpl implements SubTemplateService {
             throw e;
         } catch (Exception e) {
             throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_UPDATE_FAILED);
+        }
+    }
+
+    private void validateSubTemplateAccess(Long userId, Long templateId, Long subTemplateId) {
+        boolean accessible = subTemplateRepositoryFacade.existsValidSubTemplate(userId, templateId,
+            subTemplateId);
+
+        if (!accessible) {
+            throw new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_ACCESS_DENIED);
         }
     }
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
@@ -12,6 +12,7 @@ import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
 import com.hotpack.krocs.domain.templates.validator.TemplateValidator;
 import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.constant.ValidationConstants;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import org.springframework.util.StringUtils;
 public class TemplateServiceImpl implements TemplateService {
 
     private final TemplateRepositoryFacade templateRepositoryFacade;
+    private final UserRepositoryFacade userRepositoryFacade;
     private final TemplateConverter templateConverter;
     private final TemplateValidator templateValidator;
 
@@ -36,17 +38,13 @@ public class TemplateServiceImpl implements TemplateService {
     public TemplateCreateResponseDTO createTemplate(TemplateCreateRequestDTO requestDTO,
         Long userId) {
         try {
-
             templateValidator.validateTemplateCreateDTO(requestDTO);
-            Template template;
-            if (userId != null) {
-                User userRef = User.builder()
-                    .userId(userId)
-                    .build();
-                template = templateConverter.toEntity(requestDTO, userRef);
-            } else {
-                template = templateConverter.toEntity(requestDTO);
+
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new TemplateException(TemplateExceptionType.TEMPLATE_USER_NOT_FOUND);
             }
+            Template template = templateConverter.toEntity(requestDTO, user);
             // templateValidator.validateTemplateBusiness(template); 유효성 검사 적용 이후
             Template savedTemplate = templateRepositoryFacade.save(template);
 
@@ -61,12 +59,13 @@ public class TemplateServiceImpl implements TemplateService {
     @Override
     public List<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title) {
         try {
-            List<Template> templates;
 
+            List<Template> templates;
             if (StringUtils.hasText(title) && title.length() <= ValidationConstants.TITLE_MAX) {
-                templates = templateRepositoryFacade.findActiveTemplatesByTitle(title);
+                templates = templateRepositoryFacade.findActiveTemplatesByTitleAndUserId(title,
+                    userId);
             } else {
-                templates = templateRepositoryFacade.findAllActiveTemplates();
+                templates = templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId);
             }
 
             return templates.stream()
@@ -86,11 +85,15 @@ public class TemplateServiceImpl implements TemplateService {
         try {
             templateValidator.validateTemplateUpdateDTO(requestDTO);
 
-            Template template = templateRepositoryFacade.findActiveTemplateByTemplateId(templateId);
+            Template template = templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(
+                templateId, userId);
+            if (template == null) {
+                throw new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND);
+            }
 
             template.updateFrom(requestDTO);
-            Template updatedTemplate = templateRepositoryFacade.findActiveTemplateByTemplateId(
-                templateId);
+            Template updatedTemplate = templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(
+                templateId, userId);
 
             return templateConverter.toTemplateResponseDTO(updatedTemplate);
         } catch (TemplateException e) {
@@ -104,7 +107,11 @@ public class TemplateServiceImpl implements TemplateService {
     @Transactional
     public void deleteTemplate(Long templateId, Long userId) {
         try {
-            Template template = templateRepositoryFacade.findActiveTemplateByTemplateId(templateId);
+            Template template = templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(
+                templateId, userId);
+            if (template == null) {
+                throw new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND);
+            }
 
             templateRepositoryFacade.deleteActiveTemplate(template);
         } catch (TemplateException e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/user/converter/UserConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/user/converter/UserConverter.java
@@ -1,0 +1,18 @@
+package com.hotpack.krocs.domain.user.converter;
+
+import com.hotpack.krocs.domain.auth.dto.response.UserResponseDTO;
+import com.hotpack.krocs.domain.user.domain.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserConverter {
+
+    public static UserResponseDTO toUserResponseDTO(User user) {
+        return UserResponseDTO.builder()
+            .userId(user.getUserId())
+            .email(user.getEmail())
+            .name(user.getName())
+            .accountType(user.getAccountType())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/user/facade/UserRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/user/facade/UserRepositoryFacade.java
@@ -1,0 +1,19 @@
+package com.hotpack.krocs.domain.user.facade;
+
+import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserRepositoryFacade {
+
+    private final UserRepository userRepository;
+
+    public User findActiveUserByUserId(Long userId) {
+        return userRepository.findUserByUserId(userId);
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/user/repository/UserRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findUserByAccountIdAndStatus(String accountId, Status status);
+
+    User findUserByUserId(Long userId);
 }
 
 

--- a/backend/src/main/java/com/hotpack/krocs/global/security/resolver/LoginArgumentResolver.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/security/resolver/LoginArgumentResolver.java
@@ -17,21 +17,21 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(Login.class) && parameter.getParameterType().isAssignableFrom(UserSession.class);
+        return parameter.hasParameterAnnotation(Login.class)
+            && (parameter.getParameterType().equals(Long.class)
+            || parameter.getParameterType().equals(long.class));
     }
 
     @Override
-    public Object resolveArgument(
-            MethodParameter parameter,
-            ModelAndViewContainer mavContainer,
-            NativeWebRequest webRequest,
-            WebDataBinderFactory binderFactory
-    ) {
+    public Object resolveArgument(MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !(authentication.getPrincipal() instanceof UserSession)) {
+        if (authentication == null
+            || !(authentication.getPrincipal() instanceof UserSession userSession)) {
             throw new AccessDeniedException("Unauthenticated");
         }
-        return authentication.getPrincipal();
+        return Long.valueOf(userSession.getUserId());
     }
 }
-

--- a/backend/src/test/java/com/hotpack/krocs/AuthE2ETest.java
+++ b/backend/src/test/java/com/hotpack/krocs/AuthE2ETest.java
@@ -28,7 +28,7 @@ class AuthE2ETest {
     @BeforeEach
     void setup() {
         // 단순 문자열 JSON 저장으로 직렬화 이슈 제거
-        String json = "{\"userId\":\"u-123\",\"displayName\":\"Dev User\",\"roles\":[\"USER\"]}";
+        String json = "{\"userId\":\"1\",\"name\":\"Dev User\"}";
         stringRedisTemplate.opsForValue()
             .set("auth:token:" + TEST_TOKEN, json, Duration.ofHours(1));
     }
@@ -38,7 +38,7 @@ class AuthE2ETest {
         mockMvc.perform(get("/api/v1/auth/me").header("Authorization", "Bearer " + TEST_TOKEN))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.isSuccess").value(true))
-            .andExpect(jsonPath("$.result.userId").value("u-123"));
+            .andExpect(jsonPath("$.result.userId").value(1));
     }
 
     @Test

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -15,9 +15,10 @@ import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.request.GoalSearchRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.*;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
@@ -59,9 +60,9 @@ class GoalServiceTest {
     private SubGoalConverter subGoalConverter;
 
     @InjectMocks
-    private GoalServiceImpl subGoalService;
+    private GoalServiceImpl goalService;
     @InjectMocks
-    private SubGoalServiceImpl goalService;
+    private SubGoalServiceImpl subGoalService;
 
 
     private GoalCreateRequestDTO validRequestDTO;
@@ -83,24 +84,26 @@ class GoalServiceTest {
     private SubGoalResponseDTO validSubGoalResponseDTO;
     private SubGoalRequestDTO validSubGoalRequestDTO;
 
-    private Goal createMockGoal(Long goalId, String title, LocalDate startDate, LocalDate endDate, boolean isCompleted) {
+    private Goal createMockGoal(Long goalId, String title, LocalDate startDate, LocalDate endDate,
+        boolean isCompleted) {
         return Goal.builder()
-                .goalId(goalId)
-                .title(title)
-                .startDate(startDate)
-                .endDate(endDate)
-                .isCompleted(isCompleted)
-                .priority(Priority.MEDIUM)
-                .user(user)
-                .build();
+            .goalId(goalId)
+            .title(title)
+            .startDate(startDate)
+            .endDate(endDate)
+            .isCompleted(isCompleted)
+            .priority(Priority.MEDIUM)
+            .user(user)
+            .build();
     }
+
     private GoalResponseDTO createMockGoalResponseDTO(Long goalId, String title) {
         return GoalResponseDTO.builder()
-                .goalId(goalId)
-                .title(title)
-                .priority(Priority.MEDIUM)
-                .isCompleted(false)
-                .build();
+            .goalId(goalId)
+            .title(title)
+            .priority(Priority.MEDIUM)
+            .isCompleted(false)
+            .build();
     }
 
     @BeforeEach
@@ -112,7 +115,7 @@ class GoalServiceTest {
             .accountType(AccountType.LOCAL)
             .build();
 
-        subGoalService = new GoalServiceImpl(userRepositoryFacade, goalRepositoryFacade,
+        goalService = new GoalServiceImpl(userRepositoryFacade, goalRepositoryFacade,
             goalConverter, goalValidator);
 
         validRequestDTO = GoalCreateRequestDTO.builder()
@@ -165,6 +168,12 @@ class GoalServiceTest {
             .isCompleted(false)
             .subGoals(new ArrayList<>())
             .build();
+
+        validSubGoalResponseDTO = SubGoalResponseDTO.builder()
+            .subGoalId(validSubGoal.getSubGoalId())
+            .title(validSubGoal.getTitle())
+            .isCompleted(validSubGoal.getIsCompleted())
+            .build();
     }
 
     // ========== CREATE 테스트 ==========
@@ -180,7 +189,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalCreateResponseDTO result = subGoalService.createGoal(validRequestDTO, 1L);
+        GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -199,7 +208,7 @@ class GoalServiceTest {
         when(goalConverter.toCreateResponseDTO(any(Goal.class))).thenReturn(validResponseDTO);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        GoalCreateResponseDTO result = subGoalService.createGoal(validRequestDTO, 1L);
+        GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -217,7 +226,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.createGoal(invalidRequest, 1L))
+        assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
     }
@@ -231,7 +240,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.createGoal(invalidRequest, 1L))
+        assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
     }
@@ -247,7 +256,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.createGoal(invalidRequest, 1L))
+        assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.INVALID_GOAL_DATE_RANGE);
@@ -261,7 +270,7 @@ class GoalServiceTest {
         when(goalRepositoryFacade.saveGoal(any())).thenThrow(new RuntimeException("데이터베이스 오류"));
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when & then
-        assertThatThrownBy(() -> subGoalService.createGoal(validRequestDTO, 1L))
+        assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.GOAL_CREATION_FAILED);
@@ -274,7 +283,7 @@ class GoalServiceTest {
         when(goalConverter.toEntity(any())).thenThrow(new RuntimeException("변환 오류"));
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when & then
-        assertThatThrownBy(() -> subGoalService.createGoal(validRequestDTO, 1L))
+        assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.GOAL_CREATION_FAILED);
@@ -311,7 +320,7 @@ class GoalServiceTest {
             validGoal);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        GoalCreateResponseDTO result = subGoalService.createGoal(minimalRequest, 1L);
+        GoalCreateResponseDTO result = goalService.createGoal(minimalRequest, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -350,7 +359,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalResponseDTO result = subGoalService.updateGoalById(goalId, updateRequest, 1L);
+        GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -395,7 +404,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalResponseDTO result = subGoalService.updateGoalById(goalId, updateRequest, 1L);
+        GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -419,7 +428,7 @@ class GoalServiceTest {
             new GoalException(GoalExceptionType.GOAL_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
     }
@@ -438,7 +447,7 @@ class GoalServiceTest {
             existingGoal);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
     }
@@ -459,7 +468,7 @@ class GoalServiceTest {
             existingGoal);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.INVALID_GOAL_DATE_RANGE);
@@ -484,7 +493,7 @@ class GoalServiceTest {
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_UPDATE_FAILED);
     }
@@ -504,7 +513,7 @@ class GoalServiceTest {
             existingGoal);
 
         // when & then
-        assertThatCode(() -> subGoalService.deleteGoal(userId, goalId))
+        assertThatCode(() -> goalService.deleteGoal(userId, goalId))
             .doesNotThrowAnyException();
 
         verify(goalRepositoryFacade).existsActiveGoalById(goalId);
@@ -520,7 +529,7 @@ class GoalServiceTest {
         when(goalRepositoryFacade.existsActiveGoalById(goalId)).thenReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.deleteGoal(userId, goalId))
+        assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
 
@@ -539,7 +548,7 @@ class GoalServiceTest {
             .existsActiveGoalById(goalId);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.deleteGoal(userId, goalId))
+        assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DELETE_FAILED);
     }
@@ -572,7 +581,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalResponseDTO result = subGoalService.getGoalByGoalId(userId, goalId);
+        GoalResponseDTO result = goalService.getGoalByGoalId(userId, goalId);
 
         // then
         assertThat(result).isNotNull();
@@ -589,7 +598,7 @@ class GoalServiceTest {
         Long userId = 1L;
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.getGoalByGoalId(userId, goalId))
+        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.GOAL_INVALID_GOAL_ID);
@@ -606,7 +615,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.getGoalByGoalId(userId, goalId))
+        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
     }
@@ -622,7 +631,7 @@ class GoalServiceTest {
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.getGoalByGoalId(userId, goalId))
+        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
     }
@@ -637,29 +646,33 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> mockGoals = Arrays.asList(
-                createMockGoal(1L, "운동하기", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20), false),
-                createMockGoal(2L, "독서하기", LocalDate.now().minusDays(5), LocalDate.now().plusDays(30), false)
+            createMockGoal(1L, "운동하기", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20),
+                false),
+            createMockGoal(2L, "독서하기", LocalDate.now().minusDays(5), LocalDate.now().plusDays(30),
+                false)
         );
 
         // 정렬된 순서로 expectedResponse 생성 (독서하기가 먼저)
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(2L, "독서하기"), // ㄷ이 ㅇ보다 앞
-                createMockGoalResponseDTO(1L, "운동하기")
+            createMockGoalResponseDTO(2L, "독서하기"), // ㄷ이 ㅇ보다 앞
+            createMockGoalResponseDTO(1L, "운동하기")
         );
 
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(mockGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            mockGoals);
         when(goalConverter.toGoalResponseDTO(mockGoals)).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -681,25 +694,29 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> mockGoals = Arrays.asList(
-                createMockGoal(1L, "특정 날짜 활성 목표", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), false)
+            createMockGoal(1L, "특정 날짜 활성 목표", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31),
+                false)
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "특정 날짜 활성 목표")
+            createMockGoalResponseDTO(1L, "특정 날짜 활성 목표")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(mockGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            mockGoals);
         when(goalConverter.toGoalResponseDTO(mockGoals)).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -717,17 +734,21 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(Collections.emptyList());
-        when(goalConverter.toGoalResponseDTO(Collections.emptyList())).thenReturn(Collections.emptyList());
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            Collections.emptyList());
+        when(goalConverter.toGoalResponseDTO(Collections.emptyList())).thenReturn(
+            Collections.emptyList());
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -744,19 +765,20 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
         when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate))
-                .thenThrow(new RuntimeException("데이터베이스 오류"));
+            .thenThrow(new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.getGoalsByUser(userId, searchDate, keyword, status))
-                .isInstanceOf(GoalException.class)
-                .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
+        assertThatThrownBy(() -> goalService.getGoalsByUser(userId, searchDate, keyword, status))
+            .isInstanceOf(GoalException.class)
+            .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
     }
 
     @Test
@@ -769,27 +791,32 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> mockGoals = Arrays.asList(
-                createMockGoal(1L, "운동하기", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20), false),
-                createMockGoal(2L, "헬스장 운동", LocalDate.now().minusDays(5), LocalDate.now().plusDays(15), false)
+            createMockGoal(1L, "운동하기", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20),
+                false),
+            createMockGoal(2L, "헬스장 운동", LocalDate.now().minusDays(5), LocalDate.now().plusDays(15),
+                false)
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "운동하기"),
-                createMockGoalResponseDTO(2L, "헬스장 운동")
+            createMockGoalResponseDTO(1L, "운동하기"),
+            createMockGoalResponseDTO(2L, "헬스장 운동")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(mockGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            mockGoals);
         when(goalConverter.toGoalResponseDTO(mockGoals)).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -808,27 +835,32 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> mockGoals = Arrays.asList(
-                createMockGoal(1L, "목표1", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20), false),
-                createMockGoal(2L, "목표2", LocalDate.now().minusDays(5), LocalDate.now().plusDays(30), false)
+            createMockGoal(1L, "목표1", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20),
+                false),
+            createMockGoal(2L, "목표2", LocalDate.now().minusDays(5), LocalDate.now().plusDays(30),
+                false)
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "목표1"),
-                createMockGoalResponseDTO(2L, "목표2")
+            createMockGoalResponseDTO(1L, "목표1"),
+            createMockGoalResponseDTO(2L, "목표2")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(mockGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            mockGoals);
         when(goalConverter.toGoalResponseDTO(mockGoals)).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -845,28 +877,34 @@ class GoalServiceTest {
         String status = "COMPLETED";
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> allGoals = Arrays.asList(
-                createMockGoal(1L, "완료된 목표1", LocalDate.now().minusDays(30), LocalDate.now().minusDays(1), true),
-                createMockGoal(2L, "완료된 목표2", LocalDate.now().minusDays(20), LocalDate.now().plusDays(10), true),
-                createMockGoal(3L, "진행중 목표", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20), false)
+            createMockGoal(1L, "완료된 목표1", LocalDate.now().minusDays(30),
+                LocalDate.now().minusDays(1), true),
+            createMockGoal(2L, "완료된 목표2", LocalDate.now().minusDays(20),
+                LocalDate.now().plusDays(10), true),
+            createMockGoal(3L, "진행중 목표", LocalDate.now().minusDays(10),
+                LocalDate.now().plusDays(20), false)
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "완료된 목표1"),
-                createMockGoalResponseDTO(2L, "완료된 목표2")
+            createMockGoalResponseDTO(1L, "완료된 목표1"),
+            createMockGoalResponseDTO(2L, "완료된 목표2")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(allGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            allGoals);
         when(goalConverter.toGoalResponseDTO((List<Goal>) any())).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -885,27 +923,33 @@ class GoalServiceTest {
         String status = "IN_PROGRESS";
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> allGoals = Arrays.asList(
-                createMockGoal(1L, "진행중 목표1", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20), false),
-                createMockGoal(2L, "완료된 목표", LocalDate.now().minusDays(30), LocalDate.now().minusDays(1), true),
-                createMockGoal(3L, "기간만료 목표", LocalDate.now().minusDays(30), LocalDate.now().minusDays(1), false)
+            createMockGoal(1L, "진행중 목표1", LocalDate.now().minusDays(10),
+                LocalDate.now().plusDays(20), false),
+            createMockGoal(2L, "완료된 목표", LocalDate.now().minusDays(30),
+                LocalDate.now().minusDays(1), true),
+            createMockGoal(3L, "기간만료 목표", LocalDate.now().minusDays(30),
+                LocalDate.now().minusDays(1), false)
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "진행중 목표1")
+            createMockGoalResponseDTO(1L, "진행중 목표1")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(allGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            allGoals);
         when(goalConverter.toGoalResponseDTO((List<Goal>) any())).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -923,27 +967,33 @@ class GoalServiceTest {
         String status = "EXPIRED";
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> allGoals = Arrays.asList(
-                createMockGoal(1L, "기간만료 목표1", LocalDate.now().minusDays(30), LocalDate.now().minusDays(1), false),
-                createMockGoal(2L, "완료된 목표", LocalDate.now().minusDays(20), LocalDate.now().minusDays(1), true),
-                createMockGoal(3L, "진행중 목표", LocalDate.now().minusDays(10), LocalDate.now().plusDays(20), false)
+            createMockGoal(1L, "기간만료 목표1", LocalDate.now().minusDays(30),
+                LocalDate.now().minusDays(1), false),
+            createMockGoal(2L, "완료된 목표", LocalDate.now().minusDays(20),
+                LocalDate.now().minusDays(1), true),
+            createMockGoal(3L, "진행중 목표", LocalDate.now().minusDays(10),
+                LocalDate.now().plusDays(20), false)
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "기간만료 목표1")
+            createMockGoalResponseDTO(1L, "기간만료 목표1")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(allGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            allGoals);
         when(goalConverter.toGoalResponseDTO((List<Goal>) any())).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -961,30 +1011,36 @@ class GoalServiceTest {
         String status = null;
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> mockGoals = Arrays.asList(
-                createMockGoal(3L, "ABC영어", LocalDate.now().minusDays(10), LocalDate.of(2024, 12, 31), false),
-                createMockGoal(1L, "가나다", LocalDate.now().minusDays(5), LocalDate.of(2024, 6, 30), false),
-                createMockGoal(2L, "나다라", LocalDate.now().minusDays(3), LocalDate.of(2024, 6, 30), false)
+            createMockGoal(3L, "ABC영어", LocalDate.now().minusDays(10), LocalDate.of(2024, 12, 31),
+                false),
+            createMockGoal(1L, "가나다", LocalDate.now().minusDays(5), LocalDate.of(2024, 6, 30),
+                false),
+            createMockGoal(2L, "나다라", LocalDate.now().minusDays(3), LocalDate.of(2024, 6, 30),
+                false)
         );
 
         // 정렬된 순서로 ResponseDTO 생성 (endDate -> 한글우선제목 -> goalId)
         List<GoalResponseDTO> sortedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "가나다"), // 2024-06-30, 한글, goalId=1
-                createMockGoalResponseDTO(2L, "나다라"), // 2024-06-30, 한글, goalId=2
-                createMockGoalResponseDTO(3L, "ABC영어") // 2024-12-31, 영어
+            createMockGoalResponseDTO(1L, "가나다"), // 2024-06-30, 한글, goalId=1
+            createMockGoalResponseDTO(2L, "나다라"), // 2024-06-30, 한글, goalId=2
+            createMockGoalResponseDTO(3L, "ABC영어") // 2024-12-31, 영어
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(mockGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            mockGoals);
         when(goalConverter.toGoalResponseDTO(mockGoals)).thenReturn(sortedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -1005,28 +1061,35 @@ class GoalServiceTest {
         String status = "IN_PROGRESS";
 
         GoalSearchRequestDTO searchRequest = GoalSearchRequestDTO.builder()
-                .searchDate(searchDate)
-                .keyword(keyword)
-                .status(status)
-                .build();
+            .searchDate(searchDate)
+            .keyword(keyword)
+            .status(status)
+            .build();
 
         List<Goal> allGoals = Arrays.asList(
-                createMockGoal(1L, "운동하기", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), false), // 조건 만족
-                createMockGoal(2L, "운동완료", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), true),  // 완료됨
-                createMockGoal(3L, "독서하기", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), false), // 키워드 불일치
-                createMockGoal(4L, "운동기간만료", LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 28), false) // 기간 불일치
+            createMockGoal(1L, "운동하기", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), false),
+            // 조건 만족
+            createMockGoal(2L, "운동완료", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), true),
+            // 완료됨
+            createMockGoal(3L, "독서하기", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 3, 31), false),
+            // 키워드 불일치
+            createMockGoal(4L, "운동기간만료", LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 28), false)
+            // 기간 불일치
         );
 
         List<GoalResponseDTO> expectedResponse = Arrays.asList(
-                createMockGoalResponseDTO(1L, "운동하기")
+            createMockGoalResponseDTO(1L, "운동하기")
         );
 
-        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(searchRequest);
-        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(allGoals);
+        when(goalConverter.toGoalSearchRequestDTO(searchDate, keyword, status)).thenReturn(
+            searchRequest);
+        when(goalRepositoryFacade.findGoalsWithFilters(userId, keyword, searchDate)).thenReturn(
+            allGoals);
         when(goalConverter.toGoalResponseDTO((List<Goal>) any())).thenReturn(expectedResponse);
 
         // when
-        List<GoalResponseDTO> result = subGoalService.getGoalsByUser(userId, searchDate, keyword, status);
+        List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword,
+            status);
 
         // then
         assertThat(result).isNotNull();
@@ -1042,8 +1105,8 @@ class GoalServiceTest {
     @DisplayName("소목표 생성 성공 테스트")
     void createSubGoals_Success() {
         // given
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         List<SubGoalResponseDTO> subGoalListResponseDTO = List.of(validSubGoalResponseDTO);
-        ;
         when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalRepositoryFacade.saveSubGoals(List.of(validSubGoal))).thenReturn(
             List.of(validSubGoal));
@@ -1052,7 +1115,7 @@ class GoalServiceTest {
         when(subGoalConverter.toSubGoalEntityList(any(), any())).thenReturn(List.of(validSubGoal));
 
         // when
-        SubGoalCreateResponseDTO result = goalService.createSubGoals(1L, 1L,
+        SubGoalCreateResponseDTO result = subGoalService.createSubGoals(1L, 1L,
             validSubGoalCreateRequestDTO);
 
         // then
@@ -1070,11 +1133,13 @@ class GoalServiceTest {
     @DisplayName("소목표 생성 - GoalRepository에서 예외 발생")
     void createSubGoal_GoalsRepositoryException() {
         // given
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(any(), any())).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
@@ -1084,11 +1149,13 @@ class GoalServiceTest {
     @DisplayName("소목표 생성 - Goal 조회 실패")
     void createSubGoal_GoalsRepositoryNotFound() {
         // given
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(any(), any()))
             .thenThrow(new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
@@ -1104,7 +1171,8 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
@@ -1124,7 +1192,8 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
@@ -1145,7 +1214,8 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
@@ -1155,12 +1225,14 @@ class GoalServiceTest {
     @DisplayName("소목표 생성 - SubGoalRepository 저장 실패")
     void createSubGoal_SubGoalsRepositoryException() {
         // given
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         when(subGoalRepositoryFacade.saveSubGoals(any())).thenThrow(
             new RuntimeException("데이터베이스 오류"));
         when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -289,12 +289,8 @@ class GoalServiceTest {
             .isCompleted(false)
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())
-            .userId(user.getUserId())
             .build();
-
-        // when(goalConverter.toEntity(minimalRequest)).thenReturn(minimalGoal);
-        // when(goalRepositoryFacade.saveGoal(minimalGoal)).thenReturn(minimalGoal);
-        // when(goalConverter.toCreateResponseDTO(minimalGoal)).thenReturn(minimalResponse);
+        
         when(goalConverter.toCreateResponseDTO(any(Goal.class))).thenReturn(minimalResponse);
         when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
         when(goalConverter.toEntity(eq(minimalRequest), any(User.class))).thenReturn(

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -31,6 +31,7 @@ import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.domain.enums.AccountType;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.entity.Priority;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -55,6 +56,8 @@ class GoalServiceTest {
     private SubGoalRepositoryFacade subGoalRepositoryFacade;
     @Mock
     private SubGoalConverter subGoalConverter;
+    @Mock
+    private UserRepositoryFacade userRepositoryFacade;
 
     @InjectMocks
     private GoalServiceImpl goalService;
@@ -87,7 +90,8 @@ class GoalServiceTest {
             .accountType(AccountType.LOCAL)
             .build();
 
-        goalService = new GoalServiceImpl(subGoalRepositoryFacade, subGoalConverter,
+        goalService = new GoalServiceImpl(subGoalRepositoryFacade, userRepositoryFacade,
+            subGoalConverter,
             goalRepositoryFacade, goalConverter, goalValidator);
 
         validRequestDTO = GoalCreateRequestDTO.builder()
@@ -159,6 +163,7 @@ class GoalServiceTest {
         when(goalConverter.toCreateResponseDTO(validGoal)).thenReturn(validResponseDTO);
         when(goalConverter.toEntity(eq(validRequestDTO), any(User.class))).thenReturn(
             validGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
         GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
@@ -178,7 +183,7 @@ class GoalServiceTest {
             validGoal);
         when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
         when(goalConverter.toCreateResponseDTO(any(Goal.class))).thenReturn(validResponseDTO);
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
         GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
 
@@ -240,7 +245,7 @@ class GoalServiceTest {
         // given
         when(goalConverter.toEntity(any())).thenReturn(validGoal);
         when(goalRepositoryFacade.saveGoal(any())).thenThrow(new RuntimeException("데이터베이스 오류"));
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when & then
         assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
             .isInstanceOf(GoalException.class)
@@ -253,7 +258,7 @@ class GoalServiceTest {
     void createGoal_ConvertorException() {
         // given
         when(goalConverter.toEntity(any())).thenThrow(new RuntimeException("변환 오류"));
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when & then
         assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
             .isInstanceOf(GoalException.class)
@@ -294,7 +299,7 @@ class GoalServiceTest {
         when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
         when(goalConverter.toEntity(eq(minimalRequest), any(User.class))).thenReturn(
             validGoal);
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
         GoalCreateResponseDTO result = goalService.createGoal(minimalRequest, 1L);
 
@@ -329,8 +334,10 @@ class GoalServiceTest {
             .isCompleted(false)
             .build();
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
         when(goalConverter.toGoalResponseDTO((Goal) any())).thenReturn(expectedResponse);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
         GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
@@ -371,9 +378,11 @@ class GoalServiceTest {
             .isCompleted(false)
             .build();
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal)
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+                existingGoal)
             .thenReturn(updatedGoal);
         when(goalConverter.toGoalResponseDTO(updatedGoal)).thenReturn(expectedResponse);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
         GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
@@ -395,7 +404,8 @@ class GoalServiceTest {
             .title("수정된 제목")
             .build();
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenThrow(
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenThrow(
             new GoalException(GoalExceptionType.GOAL_NOT_FOUND));
 
         // when & then
@@ -413,7 +423,9 @@ class GoalServiceTest {
             .title("")
             .build();
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
 
         // when & then
         assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
@@ -432,7 +444,9 @@ class GoalServiceTest {
             .build();
 
         // when
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
 
         // when & then
         assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
@@ -455,7 +469,8 @@ class GoalServiceTest {
             .title("기존 제목")
             .build();
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenThrow(
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
@@ -473,8 +488,10 @@ class GoalServiceTest {
         Long goalId = 1L;
         Long userId = 1L;
 
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         when(goalRepositoryFacade.existsActiveGoalById(goalId)).thenReturn(true);
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
 
         // when & then
         assertThatCode(() -> goalService.deleteGoal(userId, goalId))
@@ -539,8 +556,10 @@ class GoalServiceTest {
             .isCompleted(false)
             .build();
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
         when(goalConverter.toGoalResponseDTO(existingGoal)).thenReturn(expectedResponse);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
         GoalResponseDTO result = goalService.getGoalByGoalId(userId, goalId);
@@ -573,7 +592,8 @@ class GoalServiceTest {
         Long goalId = 999L;
         Long userId = 1L;
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(null);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(null);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
         assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
@@ -587,8 +607,8 @@ class GoalServiceTest {
         // given
         Long goalId = 1L;
         Long userId = 1L;
-
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenThrow(
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
@@ -614,9 +634,9 @@ class GoalServiceTest {
             GoalResponseDTO.builder().goalId(2L).title("목표2").build()
         );
 
-        when(goalRepositoryFacade.findAllActiveGoals()).thenReturn(goalList);
+        when(goalRepositoryFacade.findAllActiveGoalsByUser(user)).thenReturn(goalList);
         when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
         List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
 
@@ -642,9 +662,9 @@ class GoalServiceTest {
             GoalResponseDTO.builder().goalId(1L).title("현재 진행 목표").build()
         );
 
-        when(goalRepositoryFacade.findActiveGoalByDate(date)).thenReturn(goalList);
+        when(goalRepositoryFacade.findActiveGoalByUserAndDate(user, date)).thenReturn(goalList);
         when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
         List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
 
@@ -663,9 +683,9 @@ class GoalServiceTest {
         List<Goal> emptyGoalList = Collections.emptyList();
         List<GoalResponseDTO> emptyResponse = Collections.emptyList();
 
-        when(goalRepositoryFacade.findAllActiveGoals()).thenReturn(emptyGoalList);
+        when(goalRepositoryFacade.findAllActiveGoalsByUser(user)).thenReturn(emptyGoalList);
         when(goalConverter.toGoalResponseDTO(emptyGoalList)).thenReturn(emptyResponse);
-
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
         List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
 
@@ -681,8 +701,9 @@ class GoalServiceTest {
         Long userId = 1L;
         LocalDate date = null;
 
-        when(goalRepositoryFacade.findAllActiveGoals()).thenThrow(
+        when(goalRepositoryFacade.findAllActiveGoalsByUser(user)).thenThrow(
             new RuntimeException("데이터베이스 오류"));
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
         assertThatThrownBy(() -> goalService.getGoalByUser(userId, date))
@@ -696,7 +717,7 @@ class GoalServiceTest {
         // given
         List<SubGoalResponseDTO> subGoalListResponseDTO = List.of(validSubGoalResponseDTO);
         ;
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalRepositoryFacade.saveSubGoals(List.of(validSubGoal))).thenReturn(
             List.of(validSubGoal));
         when(subGoalConverter.toSubGoalResponseListDTO(any()))
@@ -704,7 +725,8 @@ class GoalServiceTest {
         when(subGoalConverter.toSubGoalEntityList(any(), any())).thenReturn(List.of(validSubGoal));
 
         // when
-        SubGoalCreateResponseDTO result = goalService.createSubGoals(1L,
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        SubGoalCreateResponseDTO result = goalService.createSubGoals(1L, 1L,
             validSubGoalCreateRequestDTO);
 
         // then
@@ -722,11 +744,12 @@ class GoalServiceTest {
     @DisplayName("소목표 생성 - GoalRepository에서 예외 발생")
     void createSubGoal_GoalsRepositoryException() {
         // given
-        when(goalRepositoryFacade.findActiveGoalById(any())).thenThrow(
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, validSubGoalCreateRequestDTO))
+        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
@@ -736,11 +759,12 @@ class GoalServiceTest {
     @DisplayName("소목표 생성 - Goal 조회 실패")
     void createSubGoal_GoalsRepositoryNotFound() {
         // given
-        when(goalRepositoryFacade.findActiveGoalById(any()))
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L))
             .thenThrow(new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND));
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, validSubGoalCreateRequestDTO))
+        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
@@ -756,7 +780,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, invalidSubGoalCreateRequestDTO))
+        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
@@ -776,7 +800,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, invalidSubGoalCreateRequestDTO))
+        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
@@ -797,7 +821,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, invalidSubGoalCreateRequestDTO))
+        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
@@ -809,10 +833,11 @@ class GoalServiceTest {
         // given
         when(subGoalRepositoryFacade.saveSubGoals(any())).thenThrow(
             new RuntimeException("데이터베이스 오류"));
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, validSubGoalCreateRequestDTO))
+        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
@@ -835,11 +860,12 @@ class GoalServiceTest {
             validSubGoalResponseDTO
         );
 
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(subGoals);
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalConverter.toSubGoalResponseListDTO(any())).thenReturn(subGoalResponseDTOs);
         // when
-        SubGoalListResponseDTO subGoalListResponseDTO = goalService.getAllSubGoals(1L);
+        SubGoalListResponseDTO subGoalListResponseDTO = goalService.getAllSubGoals(1L, 1L);
 
         // then
         assertThat(subGoalListResponseDTO.getSubGoals().size()).isEqualTo(4);
@@ -854,7 +880,7 @@ class GoalServiceTest {
     @DisplayName("소목표 전체 조회 - goalId가 null인 경우")
     void getAllSubGoals_goalIdIsNull() {
         // when & then
-        assertThatThrownBy(() -> goalService.getAllSubGoals(null))
+        assertThatThrownBy(() -> goalService.getAllSubGoals(1L, null))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
@@ -864,12 +890,13 @@ class GoalServiceTest {
     @DisplayName("소목표 전체 조회 - SubGoalRepository에서 조회 중 예상치 못한 오류가 발생하는 경우")
     void getAllSubGoals_SubGoalRepositoryException() {
         // given
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(any())).thenThrow(
             new RuntimeException());
 
         // when & then
-        assertThatThrownBy(() -> goalService.getAllSubGoals(1L))
+        assertThatThrownBy(() -> goalService.getAllSubGoals(1L, 1L))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_READ_FAILED);
@@ -881,12 +908,16 @@ class GoalServiceTest {
         // given
         Long goalId = 1L;
 
-        when(goalRepositoryFacade.findActiveGoalById(goalId)).thenReturn(existingGoal);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(existingGoal)).thenReturn(Collections.emptyList());
-        when(subGoalConverter.toSubGoalResponseListDTO(Collections.emptyList())).thenReturn(Collections.emptyList());
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
+        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(existingGoal)).thenReturn(
+            Collections.emptyList());
+        when(subGoalConverter.toSubGoalResponseListDTO(Collections.emptyList())).thenReturn(
+            Collections.emptyList());
 
         // when
-        SubGoalListResponseDTO response = goalService.getAllSubGoals(goalId);
+        SubGoalListResponseDTO response = goalService.getAllSubGoals(1L, goalId);
 
         // then
         assertThat(response).isNotNull();
@@ -898,13 +929,14 @@ class GoalServiceTest {
     @DisplayName("소목표 단건 조회 성공")
     void getSubGoal_Success() {
         // given
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(
             List.of(validSubGoal));
         when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenReturn(validSubGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        SubGoalResponseDTO response = goalService.getSubGoal(1L, 1L);
+        SubGoalResponseDTO response = goalService.getSubGoal(1L, 1L, 1L);
 
         // then
         assertThat(response).isEqualTo(subGoalConverter.toSubGoalResponseDTO(validSubGoal));
@@ -914,7 +946,7 @@ class GoalServiceTest {
     @DisplayName("소목표 단건 조회 - subGoalId가 null인 경우")
     void getSubGoal_subGoalIdIsNull() {
         // when & then
-        assertThatThrownBy(() -> goalService.getSubGoal(1L, null))
+        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L, null))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
@@ -924,14 +956,15 @@ class GoalServiceTest {
     @DisplayName("소목표 단건 조회 - SubGoalRepository 조회 결과 없는 경우")
     void getSubGoal_subGoalRepositoryResultIsNull() {
         // given
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(
             List.of(validSubGoal));
         when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenThrow(
             new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_FOUND));
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
-        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L))
+        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L, validSubGoal.getSubGoalId()))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_NOT_FOUND);
@@ -941,13 +974,14 @@ class GoalServiceTest {
     @DisplayName("소목표 단건 조회 - 소목표가 해당 목표에 속하지 않음")
     void getSubGoal_SubGoalNotBelongToGoal() {
         // given
-        when(goalRepositoryFacade.findActiveGoalById(1L)).thenReturn(validGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
         when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(
             new ArrayList<>());
         when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenReturn(validSubGoal);
 
         // when & then
-        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L))
+        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L, validSubGoal.getSubGoalId()))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_NOT_BELONG_TO_GOAL);

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -11,24 +11,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hotpack.krocs.domain.goals.converter.GoalConverter;
-import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
-import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
-import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
-import com.hotpack.krocs.domain.goals.exception.SubGoalException;
-import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
-import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.domain.enums.AccountType;
 import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
@@ -53,14 +45,10 @@ class GoalServiceTest {
     @Mock
     private GoalRepositoryFacade goalRepositoryFacade;
     @Mock
-    private SubGoalRepositoryFacade subGoalRepositoryFacade;
-    @Mock
-    private SubGoalConverter subGoalConverter;
-    @Mock
     private UserRepositoryFacade userRepositoryFacade;
 
     @InjectMocks
-    private GoalServiceImpl goalService;
+    private GoalServiceImpl subGoalService;
 
     private GoalCreateRequestDTO validRequestDTO;
     private Goal validGoal;
@@ -69,16 +57,14 @@ class GoalServiceTest {
     @Mock
     private GoalConverter goalConverter;
 
-    //    private GoalServiceImpl goalService;
+    //    private GoalServiceImpl subGoalService;
     private GoalValidator goalValidator = new GoalValidator();
 
     private Goal existingGoal;
 
     private User user;
 
-    private SubGoalCreateRequestDTO validSubGoalCreateRequestDTO;
     private SubGoal validSubGoal;
-    private SubGoalResponseDTO validSubGoalResponseDTO;
     private SubGoalRequestDTO validSubGoalRequestDTO;
 
     @BeforeEach
@@ -90,9 +76,8 @@ class GoalServiceTest {
             .accountType(AccountType.LOCAL)
             .build();
 
-        goalService = new GoalServiceImpl(subGoalRepositoryFacade, userRepositoryFacade,
-            subGoalConverter,
-            goalRepositoryFacade, goalConverter, goalValidator);
+        subGoalService = new GoalServiceImpl(userRepositoryFacade, goalRepositoryFacade,
+            goalConverter, goalValidator);
 
         validRequestDTO = GoalCreateRequestDTO.builder()
             .title("테스트 목표")
@@ -126,21 +111,11 @@ class GoalServiceTest {
             .title("테스트 소목표1")
             .build();
 
-        validSubGoalCreateRequestDTO = SubGoalCreateRequestDTO.builder()
-            .subGoals(List.of(validSubGoalRequestDTO))
-            .build();
-
         validSubGoal = SubGoal.builder()
             .subGoalId(1L)
             .goal(validGoal)
             .title("테스트 소목표1")
             .isCompleted(false)
-            .build();
-
-        validSubGoalResponseDTO = SubGoalResponseDTO.builder()
-            .subGoalId(validSubGoal.getSubGoalId())
-            .title(validSubGoal.getTitle())
-            .isCompleted(validSubGoal.getIsCompleted())
             .build();
 
         existingGoal = Goal.builder()
@@ -158,7 +133,6 @@ class GoalServiceTest {
     @DisplayName("대목표 생성 성공 테스트")
     void createGoal_Success() {
         // given
-//        when(goalConverter.toEntity(validRequestDTO)).thenReturn(validGoal);
         when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
         when(goalConverter.toCreateResponseDTO(validGoal)).thenReturn(validResponseDTO);
         when(goalConverter.toEntity(eq(validRequestDTO), any(User.class))).thenReturn(
@@ -166,7 +140,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
+        GoalCreateResponseDTO result = subGoalService.createGoal(validRequestDTO, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -185,7 +159,7 @@ class GoalServiceTest {
         when(goalConverter.toCreateResponseDTO(any(Goal.class))).thenReturn(validResponseDTO);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        GoalCreateResponseDTO result = goalService.createGoal(validRequestDTO, 1L);
+        GoalCreateResponseDTO result = subGoalService.createGoal(validRequestDTO, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -203,7 +177,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.createGoal(invalidRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
     }
@@ -217,7 +191,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.createGoal(invalidRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
     }
@@ -233,7 +207,7 @@ class GoalServiceTest {
             .build();
 
         // when & then
-        assertThatThrownBy(() -> goalService.createGoal(invalidRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.createGoal(invalidRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.INVALID_GOAL_DATE_RANGE);
@@ -247,7 +221,7 @@ class GoalServiceTest {
         when(goalRepositoryFacade.saveGoal(any())).thenThrow(new RuntimeException("데이터베이스 오류"));
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when & then
-        assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
+        assertThatThrownBy(() -> subGoalService.createGoal(validRequestDTO, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.GOAL_CREATION_FAILED);
@@ -260,7 +234,7 @@ class GoalServiceTest {
         when(goalConverter.toEntity(any())).thenThrow(new RuntimeException("변환 오류"));
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when & then
-        assertThatThrownBy(() -> goalService.createGoal(validRequestDTO, 1L))
+        assertThatThrownBy(() -> subGoalService.createGoal(validRequestDTO, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.GOAL_CREATION_FAILED);
@@ -290,14 +264,14 @@ class GoalServiceTest {
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())
             .build();
-        
+
         when(goalConverter.toCreateResponseDTO(any(Goal.class))).thenReturn(minimalResponse);
         when(goalRepositoryFacade.saveGoal(validGoal)).thenReturn(validGoal);
         when(goalConverter.toEntity(eq(minimalRequest), any(User.class))).thenReturn(
             validGoal);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        GoalCreateResponseDTO result = goalService.createGoal(minimalRequest, 1L);
+        GoalCreateResponseDTO result = subGoalService.createGoal(minimalRequest, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -336,7 +310,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
+        GoalResponseDTO result = subGoalService.updateGoalById(goalId, updateRequest, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -381,7 +355,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalResponseDTO result = goalService.updateGoalById(goalId, updateRequest, 1L);
+        GoalResponseDTO result = subGoalService.updateGoalById(goalId, updateRequest, 1L);
 
         // then
         assertThat(result).isNotNull();
@@ -405,7 +379,7 @@ class GoalServiceTest {
             new GoalException(GoalExceptionType.GOAL_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
     }
@@ -424,7 +398,7 @@ class GoalServiceTest {
             existingGoal);
 
         // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_TITLE_EMPTY);
     }
@@ -445,7 +419,7 @@ class GoalServiceTest {
             existingGoal);
 
         // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.INVALID_GOAL_DATE_RANGE);
@@ -470,7 +444,7 @@ class GoalServiceTest {
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> goalService.updateGoalById(goalId, updateRequest, 1L))
+        assertThatThrownBy(() -> subGoalService.updateGoalById(goalId, updateRequest, 1L))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_UPDATE_FAILED);
     }
@@ -490,7 +464,7 @@ class GoalServiceTest {
             existingGoal);
 
         // when & then
-        assertThatCode(() -> goalService.deleteGoal(userId, goalId))
+        assertThatCode(() -> subGoalService.deleteGoal(userId, goalId))
             .doesNotThrowAnyException();
 
         verify(goalRepositoryFacade).existsActiveGoalById(goalId);
@@ -506,7 +480,7 @@ class GoalServiceTest {
         when(goalRepositoryFacade.existsActiveGoalById(goalId)).thenReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
+        assertThatThrownBy(() -> subGoalService.deleteGoal(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
 
@@ -525,7 +499,7 @@ class GoalServiceTest {
             .existsActiveGoalById(goalId);
 
         // when & then
-        assertThatThrownBy(() -> goalService.deleteGoal(userId, goalId))
+        assertThatThrownBy(() -> subGoalService.deleteGoal(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_DELETE_FAILED);
     }
@@ -558,7 +532,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when
-        GoalResponseDTO result = goalService.getGoalByGoalId(userId, goalId);
+        GoalResponseDTO result = subGoalService.getGoalByGoalId(userId, goalId);
 
         // then
         assertThat(result).isNotNull();
@@ -575,7 +549,7 @@ class GoalServiceTest {
         Long userId = 1L;
 
         // when & then
-        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
+        assertThatThrownBy(() -> subGoalService.getGoalByGoalId(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType",
                 GoalExceptionType.GOAL_INVALID_GOAL_ID);
@@ -592,7 +566,7 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
-        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
+        assertThatThrownBy(() -> subGoalService.getGoalByGoalId(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_NOT_FOUND);
     }
@@ -608,7 +582,7 @@ class GoalServiceTest {
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> goalService.getGoalByGoalId(userId, goalId))
+        assertThatThrownBy(() -> subGoalService.getGoalByGoalId(userId, goalId))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
     }
@@ -634,7 +608,7 @@ class GoalServiceTest {
         when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
+        List<GoalResponseDTO> result = subGoalService.getGoalByUser(userId, date);
 
         // then
         assertThat(result).isNotNull();
@@ -662,7 +636,7 @@ class GoalServiceTest {
         when(goalConverter.toGoalResponseDTO(goalList)).thenReturn(expectedResponse);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
+        List<GoalResponseDTO> result = subGoalService.getGoalByUser(userId, date);
 
         // then
         assertThat(result).isNotNull();
@@ -683,7 +657,7 @@ class GoalServiceTest {
         when(goalConverter.toGoalResponseDTO(emptyGoalList)).thenReturn(emptyResponse);
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         // when
-        List<GoalResponseDTO> result = goalService.getGoalByUser(userId, date);
+        List<GoalResponseDTO> result = subGoalService.getGoalByUser(userId, date);
 
         // then
         assertThat(result).isNotNull();
@@ -702,284 +676,10 @@ class GoalServiceTest {
         when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
 
         // when & then
-        assertThatThrownBy(() -> goalService.getGoalByUser(userId, date))
+        assertThatThrownBy(() -> subGoalService.getGoalByUser(userId, date))
             .isInstanceOf(GoalException.class)
             .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_FOUND_FAILED);
     }
 
-    @Test
-    @DisplayName("소목표 생성 성공 테스트")
-    void createSubGoals_Success() {
-        // given
-        List<SubGoalResponseDTO> subGoalListResponseDTO = List.of(validSubGoalResponseDTO);
-        ;
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(subGoalRepositoryFacade.saveSubGoals(List.of(validSubGoal))).thenReturn(
-            List.of(validSubGoal));
-        when(subGoalConverter.toSubGoalResponseListDTO(any()))
-            .thenReturn(subGoalListResponseDTO);
-        when(subGoalConverter.toSubGoalEntityList(any(), any())).thenReturn(List.of(validSubGoal));
 
-        // when
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        SubGoalCreateResponseDTO result = goalService.createSubGoals(1L, 1L,
-            validSubGoalCreateRequestDTO);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getGoalId()).isEqualTo(1L);
-        assertThat(result.getCreatedSubGoals()).isNotEmpty();
-        for (SubGoalResponseDTO subGoalRequestDTO : result.getCreatedSubGoals()) {
-            assertThat(subGoalRequestDTO.getSubGoalId()).isEqualTo(1L);
-            assertThat(subGoalRequestDTO.getTitle()).isEqualTo("테스트 소목표1");
-            assertThat(subGoalRequestDTO.getIsCompleted()).isEqualTo(false);
-        }
-    }
-
-    @Test
-    @DisplayName("소목표 생성 - GoalRepository에서 예외 발생")
-    void createSubGoal_GoalsRepositoryException() {
-        // given
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenThrow(
-            new RuntimeException("데이터베이스 오류"));
-
-        // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
-    }
-
-    @Test
-    @DisplayName("소목표 생성 - Goal 조회 실패")
-    void createSubGoal_GoalsRepositoryNotFound() {
-        // given
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L))
-            .thenThrow(new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND));
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("소목표 생성 - SubGoalCreateRequest.subGoals()가 비어있는 리스트인 경우")
-    void createSubGoals_subGoalsIsEmpty() {
-        // given
-        SubGoalCreateRequestDTO invalidSubGoalCreateRequestDTO = SubGoalCreateRequestDTO
-            .builder()
-            .subGoals(new ArrayList<>())
-            .build();
-
-        // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
-    }
-
-    @Test
-    @DisplayName("소목표 생성 - SubGoalRequestDTO.title()이 Blank인 경우")
-    void createSubGoals_titleIsBlank() {
-        // given
-        SubGoalRequestDTO invalidSubGoalRequestDTO = SubGoalRequestDTO
-            .builder()
-            .title("")
-            .build();
-        SubGoalCreateRequestDTO invalidSubGoalCreateRequestDTO = SubGoalCreateRequestDTO
-            .builder()
-            .subGoals(List.of(invalidSubGoalRequestDTO))
-            .build();
-
-        // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
-    }
-
-    @Test
-    @DisplayName("소목표 생성 - SubGoalRequestDTO.title()이 200자를 초과하는 경우")
-    void createSubGoals_titleExceedsMaxLength() {
-        // given
-        SubGoalRequestDTO invalidSubGoalRequestDTO = SubGoalRequestDTO
-            .builder()
-            .title(
-                "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")
-            .build();
-        SubGoalCreateRequestDTO invalidSubGoalCreateRequestDTO = SubGoalCreateRequestDTO
-            .builder()
-            .subGoals(List.of(invalidSubGoalRequestDTO))
-            .build();
-
-        // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
-    }
-
-    @Test
-    @DisplayName("소목표 생성 - SubGoalRepository 저장 실패")
-    void createSubGoal_SubGoalsRepositoryException() {
-        // given
-        when(subGoalRepositoryFacade.saveSubGoals(any())).thenThrow(
-            new RuntimeException("데이터베이스 오류"));
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
-    }
-
-    // SubGoal 전체 조회 test code
-    @Test
-    @DisplayName("소목표 전체 조회 성공")
-    void getAllSubGoals_Success() {
-        // given
-        List<SubGoal> subGoals = new ArrayList<>();
-        subGoals.add(validSubGoal);
-        subGoals.add(validSubGoal);
-        subGoals.add(validSubGoal);
-        subGoals.add(validSubGoal);
-        List<SubGoalResponseDTO> subGoalResponseDTOs = List.of(
-            validSubGoalResponseDTO,
-            validSubGoalResponseDTO,
-            validSubGoalResponseDTO,
-            validSubGoalResponseDTO
-        );
-
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(subGoals);
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(subGoalConverter.toSubGoalResponseListDTO(any())).thenReturn(subGoalResponseDTOs);
-        // when
-        SubGoalListResponseDTO subGoalListResponseDTO = goalService.getAllSubGoals(1L, 1L);
-
-        // then
-        assertThat(subGoalListResponseDTO.getSubGoals().size()).isEqualTo(4);
-        assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getSubGoalId()).isEqualTo(1L);
-        assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getIsCompleted()).isEqualTo(
-            false);
-        assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getTitle()).isEqualTo(
-            "테스트 소목표1");
-    }
-
-    @Test
-    @DisplayName("소목표 전체 조회 - goalId가 null인 경우")
-    void getAllSubGoals_goalIdIsNull() {
-        // when & then
-        assertThatThrownBy(() -> goalService.getAllSubGoals(1L, null))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
-    }
-
-    @Test
-    @DisplayName("소목표 전체 조회 - SubGoalRepository에서 조회 중 예상치 못한 오류가 발생하는 경우")
-    void getAllSubGoals_SubGoalRepositoryException() {
-        // given
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(any())).thenThrow(
-            new RuntimeException());
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getAllSubGoals(1L, 1L))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_READ_FAILED);
-    }
-
-    @Test
-    @DisplayName("소목표 전체 조회 성공 - 해당하는 소목표가 없을 때 빈 리스트 반환")
-    void getAllSubGoals_whenNoSubGoalsExist_returnsEmptyList() {
-        // given
-        Long goalId = 1L;
-
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
-            existingGoal);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(existingGoal)).thenReturn(
-            Collections.emptyList());
-        when(subGoalConverter.toSubGoalResponseListDTO(Collections.emptyList())).thenReturn(
-            Collections.emptyList());
-
-        // when
-        SubGoalListResponseDTO response = goalService.getAllSubGoals(1L, goalId);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.getSubGoals()).isNotNull();
-        assertThat(response.getSubGoals()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("소목표 단건 조회 성공")
-    void getSubGoal_Success() {
-        // given
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(
-            List.of(validSubGoal));
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenReturn(validSubGoal);
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-
-        // when
-        SubGoalResponseDTO response = goalService.getSubGoal(1L, 1L, 1L);
-
-        // then
-        assertThat(response).isEqualTo(subGoalConverter.toSubGoalResponseDTO(validSubGoal));
-    }
-
-    @Test
-    @DisplayName("소목표 단건 조회 - subGoalId가 null인 경우")
-    void getSubGoal_subGoalIdIsNull() {
-        // when & then
-        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L, null))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
-    }
-
-    @Test
-    @DisplayName("소목표 단건 조회 - SubGoalRepository 조회 결과 없는 경우")
-    void getSubGoal_subGoalRepositoryResultIsNull() {
-        // given
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(
-            List.of(validSubGoal));
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenThrow(
-            new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_FOUND));
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L, validSubGoal.getSubGoalId()))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("소목표 단건 조회 - 소목표가 해당 목표에 속하지 않음")
-    void getSubGoal_SubGoalNotBelongToGoal() {
-        // given
-        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
-        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
-        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(
-            new ArrayList<>());
-        when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenReturn(validSubGoal);
-
-        // when & then
-        assertThatThrownBy(() -> goalService.getSubGoal(1L, 1L, validSubGoal.getSubGoalId()))
-            .isInstanceOf(SubGoalException.class)
-            .hasFieldOrPropertyWithValue("subGoalExceptionType",
-                SubGoalExceptionType.SUB_GOAL_NOT_BELONG_TO_GOAL);
-    }
 } 

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/SubGoalServiceTest.java
@@ -10,13 +10,25 @@ import static org.mockito.Mockito.when;
 import com.hotpack.krocs.domain.goals.converter.SubGoalConverter;
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.domain.SubGoal;
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalUpdateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalListResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalUpdateResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
+import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
+import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.domain.enums.AccountType;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.entity.Priority;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +43,10 @@ class SubGoalServiceTest {
     @Mock
     private SubGoalRepositoryFacade subGoalRepositoryFacade;
     @Mock
+    private GoalRepositoryFacade goalRepositoryFacade;
+    @Mock
+    private UserRepositoryFacade userRepositoryFacade;
+    @Mock
     private SubGoalConverter subGoalConverter;
 
     @InjectMocks
@@ -38,15 +54,35 @@ class SubGoalServiceTest {
 
     private SubGoalUpdateRequestDTO validSubGoalUpdateRequestDTO;
     private SubGoal validSubGoal;
+    private SubGoalResponseDTO validSubGoalResponseDTO;
+    private SubGoalCreateRequestDTO validSubGoalCreateRequestDTO;
+    private SubGoalRequestDTO validSubGoalRequestDTO;
+    private User user;
+    private Goal validGoal;
+    private Goal existingGoal;
 
     @BeforeEach
     void setUp() {
+        user = User.builder()
+            .name("박성열")
+            .email("qkrtjdduf@example.com")
+            .accountType(AccountType.LOCAL)
+            .build();
+
+        validSubGoalRequestDTO = SubGoalRequestDTO.builder()
+            .title("테스트 소목표1")
+            .build();
+
+        validSubGoalCreateRequestDTO = SubGoalCreateRequestDTO.builder()
+            .subGoals(List.of(validSubGoalRequestDTO))
+            .build();
+
         validSubGoalUpdateRequestDTO = SubGoalUpdateRequestDTO.builder()
             .title("테스트 변경 소목표 제목")
             .isCompleted(true)
             .build();
 
-        Goal validGoal = Goal.builder()
+        validGoal = Goal.builder()
             .goalId(1L)
             .title("테스트 목표")
             .priority(Priority.HIGH)
@@ -61,6 +97,241 @@ class SubGoalServiceTest {
             .title("테스트 소목표1")
             .isCompleted(false)
             .build();
+
+        existingGoal = Goal.builder()
+            .goalId(1L)
+            .title("기존 제목")  // 원래 제목
+            .priority(Priority.HIGH)
+            .isCompleted(false)
+            .subGoals(new ArrayList<>())
+            .build();
+
+        validSubGoalResponseDTO = SubGoalResponseDTO.builder()
+            .subGoalId(validSubGoal.getSubGoalId())
+            .title(validSubGoal.getTitle())
+            .isCompleted(validSubGoal.getIsCompleted())
+            .build();
+    }
+
+
+    @Test
+    @DisplayName("소목표 생성 성공 테스트")
+    void createSubGoals_Success() {
+        // given
+        List<SubGoalResponseDTO> subGoalListResponseDTO = List.of(validSubGoalResponseDTO);
+        ;
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
+        when(subGoalRepositoryFacade.saveSubGoals(List.of(validSubGoal))).thenReturn(
+            List.of(validSubGoal));
+        when(subGoalConverter.toSubGoalResponseListDTO(any()))
+            .thenReturn(subGoalListResponseDTO);
+        when(subGoalConverter.toSubGoalEntityList(any(), any())).thenReturn(List.of(validSubGoal));
+
+        // when
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        SubGoalCreateResponseDTO result = subGoalService.createSubGoals(1L, 1L,
+            validSubGoalCreateRequestDTO);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getGoalId()).isEqualTo(1L);
+        assertThat(result.getCreatedSubGoals()).isNotEmpty();
+        for (SubGoalResponseDTO subGoalRequestDTO : result.getCreatedSubGoals()) {
+            assertThat(subGoalRequestDTO.getSubGoalId()).isEqualTo(1L);
+            assertThat(subGoalRequestDTO.getTitle()).isEqualTo("테스트 소목표1");
+            assertThat(subGoalRequestDTO.getIsCompleted()).isEqualTo(false);
+        }
+    }
+
+    @Test
+    @DisplayName("소목표 생성 - GoalRepository에서 예외 발생")
+    void createSubGoal_GoalsRepositoryException() {
+        // given
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenThrow(
+            new RuntimeException("데이터베이스 오류"));
+
+        // when & then
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
+    }
+
+    @Test
+    @DisplayName("소목표 생성 - Goal 조회 실패")
+    void createSubGoal_GoalsRepositoryNotFound() {
+        // given
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L))
+            .thenThrow(new SubGoalException(SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND));
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+
+        // when & then
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_GOAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("소목표 생성 - SubGoalCreateRequest.subGoals()가 비어있는 리스트인 경우")
+    void createSubGoals_subGoalsIsEmpty() {
+        // given
+        SubGoalCreateRequestDTO invalidSubGoalCreateRequestDTO = SubGoalCreateRequestDTO
+            .builder()
+            .subGoals(new ArrayList<>())
+            .build();
+
+        // when & then
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_CREATE_EMPTY);
+    }
+
+    @Test
+    @DisplayName("소목표 생성 - SubGoalRequestDTO.title()이 Blank인 경우")
+    void createSubGoals_titleIsBlank() {
+        // given
+        SubGoalRequestDTO invalidSubGoalRequestDTO = SubGoalRequestDTO
+            .builder()
+            .title("")
+            .build();
+        SubGoalCreateRequestDTO invalidSubGoalCreateRequestDTO = SubGoalCreateRequestDTO
+            .builder()
+            .subGoals(List.of(invalidSubGoalRequestDTO))
+            .build();
+
+        // when & then
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_TITLE_EMPTY);
+    }
+
+    @Test
+    @DisplayName("소목표 생성 - SubGoalRequestDTO.title()이 200자를 초과하는 경우")
+    void createSubGoals_titleExceedsMaxLength() {
+        // given
+        SubGoalRequestDTO invalidSubGoalRequestDTO = SubGoalRequestDTO
+            .builder()
+            .title(
+                "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901")
+            .build();
+        SubGoalCreateRequestDTO invalidSubGoalCreateRequestDTO = SubGoalCreateRequestDTO
+            .builder()
+            .subGoals(List.of(invalidSubGoalRequestDTO))
+            .build();
+
+        // when & then
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, invalidSubGoalCreateRequestDTO))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
+    }
+
+    @Test
+    @DisplayName("소목표 생성 - SubGoalRepository 저장 실패")
+    void createSubGoal_SubGoalsRepositoryException() {
+        // given
+        when(subGoalRepositoryFacade.saveSubGoals(any())).thenThrow(
+            new RuntimeException("데이터베이스 오류"));
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+
+        // when & then
+        assertThatThrownBy(
+            () -> subGoalService.createSubGoals(1L, 1L, validSubGoalCreateRequestDTO))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_CREATE_FAILED);
+    }
+
+    // SubGoal 전체 조회 test code
+    @Test
+    @DisplayName("소목표 전체 조회 성공")
+    void getAllSubGoals_Success() {
+        // given
+        List<SubGoal> subGoals = new ArrayList<>();
+        subGoals.add(validSubGoal);
+        subGoals.add(validSubGoal);
+        subGoals.add(validSubGoal);
+        subGoals.add(validSubGoal);
+        List<SubGoalResponseDTO> subGoalResponseDTOs = List.of(
+            validSubGoalResponseDTO,
+            validSubGoalResponseDTO,
+            validSubGoalResponseDTO,
+            validSubGoalResponseDTO
+        );
+
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(validGoal)).thenReturn(subGoals);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
+        when(subGoalConverter.toSubGoalResponseListDTO(any())).thenReturn(subGoalResponseDTOs);
+        // when
+        SubGoalListResponseDTO subGoalListResponseDTO = subGoalService.getAllSubGoals(1L, 1L);
+
+        // then
+        assertThat(subGoalListResponseDTO.getSubGoals().size()).isEqualTo(4);
+        assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getSubGoalId()).isEqualTo(1L);
+        assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getIsCompleted()).isEqualTo(
+            false);
+        assertThat(subGoalListResponseDTO.getSubGoals().getFirst().getTitle()).isEqualTo(
+            "테스트 소목표1");
+    }
+
+    @Test
+    @DisplayName("소목표 전체 조회 - goalId가 null인 경우")
+    void getAllSubGoals_goalIdIsNull() {
+        // when & then
+        assertThatThrownBy(() -> subGoalService.getAllSubGoals(1L, null))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_GOAL_ID_IS_NULL);
+    }
+
+    @Test
+    @DisplayName("소목표 전체 조회 - SubGoalRepository에서 조회 중 예상치 못한 오류가 발생하는 경우")
+    void getAllSubGoals_SubGoalRepositoryException() {
+        // given
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, 1L)).thenReturn(validGoal);
+        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(any())).thenThrow(
+            new RuntimeException());
+
+        // when & then
+        assertThatThrownBy(() -> subGoalService.getAllSubGoals(1L, 1L))
+            .isInstanceOf(SubGoalException.class)
+            .hasFieldOrPropertyWithValue("subGoalExceptionType",
+                SubGoalExceptionType.SUB_GOAL_READ_FAILED);
+    }
+
+    @Test
+    @DisplayName("소목표 전체 조회 성공 - 해당하는 소목표가 없을 때 빈 리스트 반환")
+    void getAllSubGoals_whenNoSubGoalsExist_returnsEmptyList() {
+        // given
+        Long goalId = 1L;
+
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveGoalByUserAndGoalId(user, goalId)).thenReturn(
+            existingGoal);
+        when(subGoalRepositoryFacade.findActiveSubGoalsByGoal(existingGoal)).thenReturn(
+            Collections.emptyList());
+        when(subGoalConverter.toSubGoalResponseListDTO(Collections.emptyList())).thenReturn(
+            Collections.emptyList());
+
+        // when
+        SubGoalListResponseDTO response = subGoalService.getAllSubGoals(1L, goalId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getSubGoals()).isNotNull();
+        assertThat(response.getSubGoals()).isEmpty();
     }
 
     @Test
@@ -75,9 +346,10 @@ class SubGoalServiceTest {
 
         // given
         when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(1L)).thenReturn(validSubGoal);
+        when(subGoalRepositoryFacade.existsValidSubGoal(1L, 1L, 1L)).thenReturn(true);
 
         // when
-        SubGoalUpdateResponseDTO responseDTO = subGoalService.updateSubGoal(1L,
+        SubGoalUpdateResponseDTO responseDTO = subGoalService.updateSubGoal(1L, 1L, 1L,
             validSubGoalUpdateRequestDTO);
 
         // then
@@ -89,7 +361,8 @@ class SubGoalServiceTest {
     @DisplayName("소목표 수정 - subGoalId가 null인 경우")
     void updateSubGoal_subGoalIdIsNull() {
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateSubGoal(null, validSubGoalUpdateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.updateSubGoal(1L, 1L, null, validSubGoalUpdateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_ID_IS_NULL);
@@ -104,9 +377,10 @@ class SubGoalServiceTest {
                 "더하면열글자가되어요".repeat(21))
             .isCompleted(false)
             .build();
+        when(subGoalRepositoryFacade.existsValidSubGoal(1L, 1L, 1L)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateSubGoal(1L, invalidRequestDTO))
+        assertThatThrownBy(() -> subGoalService.updateSubGoal(1L, 1L, 1L, invalidRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_TITLE_TOO_LONG);
@@ -118,9 +392,11 @@ class SubGoalServiceTest {
         // given
         when(subGoalRepositoryFacade.findActiveSubGoalBySubGoalId(any())).thenThrow(
             new RuntimeException());
+        when(subGoalRepositoryFacade.existsValidSubGoal(1L, 1L, 1L)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.updateSubGoal(1L, validSubGoalUpdateRequestDTO))
+        assertThatThrownBy(
+            () -> subGoalService.updateSubGoal(1L, 1L, 1L, validSubGoalUpdateRequestDTO))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_UPDATE_FAILED);
@@ -131,9 +407,10 @@ class SubGoalServiceTest {
     void deleteSubGoal_Success() {
         // given
         Long subGoalId = 1L;
+        when(subGoalRepositoryFacade.existsValidSubGoal(1L, 1L, 1L)).thenReturn(true);
 
         // when
-        subGoalService.deleteSubGoal(subGoalId);
+        subGoalService.deleteSubGoal(1L, 1L, subGoalId);
 
         // then
         verify(subGoalRepositoryFacade).deleteActiveSubGoalBySubGoalId(subGoalId);
@@ -146,9 +423,10 @@ class SubGoalServiceTest {
         doThrow(new SubGoalException(SubGoalExceptionType.SUB_GOAL_NOT_FOUND))
             .when(subGoalRepositoryFacade)
             .deleteActiveSubGoalBySubGoalId(any());
+        when(subGoalRepositoryFacade.existsValidSubGoal(1L, 1L, 1L)).thenReturn(true);
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.deleteSubGoal(1L))
+        assertThatThrownBy(() -> subGoalService.deleteSubGoal(1L, 1L, 1L))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_NOT_FOUND);
@@ -158,12 +436,15 @@ class SubGoalServiceTest {
     @Test
     @DisplayName("소목표 삭제 - 예상치 못한 예외 발생")
     void deleteSubGoal_UnknownException() {
+
+        when(subGoalRepositoryFacade.existsValidSubGoal(1L, 1L, 1L)).thenReturn(true);
+
         doThrow(new RuntimeException())
             .when(subGoalRepositoryFacade)
             .deleteActiveSubGoalBySubGoalId(any());
 
         // when & then
-        assertThatThrownBy(() -> subGoalService.deleteSubGoal(1L))
+        assertThatThrownBy(() -> subGoalService.deleteSubGoal(1L, 1L, 1L))
             .isInstanceOf(SubGoalException.class)
             .hasFieldOrPropertyWithValue("subGoalExceptionType",
                 SubGoalExceptionType.SUB_GOAL_DELETE_FAILED);

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/converter/SubPlanConverterTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/converter/SubPlanConverterTest.java
@@ -60,7 +60,7 @@ class SubPlanConverterTest {
             .build();
 
         // when
-        List<SubPlan> subPlans = subPlanConverter.toSubPlanEntityList(testPlan, createRequest);
+        List<SubPlan> subPlans = subPlanConverter.toEntityList(testPlan, createRequest);
 
         // then
         assertThat(subPlans).hasSize(2);

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/service/PlanServiceTest.java
@@ -12,9 +12,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.hotpack.krocs.domain.goals.domain.Goal;
-import com.hotpack.krocs.domain.goals.domain.SubGoal;
-import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
 import com.hotpack.krocs.domain.plans.converter.PlanConverter;
 import com.hotpack.krocs.domain.plans.domain.Color;
 import com.hotpack.krocs.domain.plans.domain.Plan;
@@ -28,11 +25,14 @@ import com.hotpack.krocs.domain.plans.exception.PlanExceptionType;
 import com.hotpack.krocs.domain.plans.facade.PlanRepositoryFacade;
 import com.hotpack.krocs.domain.plans.validator.PlanValidator;
 import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.domain.enums.AccountType;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,9 +48,9 @@ public class PlanServiceTest {
     @Mock
     private PlanRepositoryFacade planRepositoryFacade;
     @Mock
-    private PlanConverter planConverter;
+    private UserRepositoryFacade userRepositoryFacade;
     @Mock
-    private SubGoalRepositoryFacade subGoalRepositoryFacade;
+    private PlanConverter planConverter;
     @Mock
     private PlanValidator planValidator;
 
@@ -63,11 +63,17 @@ public class PlanServiceTest {
     private PlanResponseDTO validResponseDTO;
     private List<Plan> validPlanList;
     private List<PlanResponseDTO> validPlanResponseList;
-    private PlanListResponseDTO validPlanListResponseDTO;
+    private User user;
 
     @BeforeEach
     void setUp() {
         // 테스트 데이터 초기화
+        user = User.builder()
+            .name("박성열")
+            .email("qkrtjdduf@example.com")
+            .accountId("local-" + UUID.randomUUID())
+            .accountType(AccountType.LOCAL)
+            .build();
 
         validRequestDTO = PlanCreateRequestDTO.builder()
             .title("테스트 일정")
@@ -125,10 +131,6 @@ public class PlanServiceTest {
             .build();
 
         validPlanResponseList = Arrays.asList(validResponseDTO, responseDTO2);
-
-        validPlanListResponseDTO = PlanListResponseDTO.builder()
-            .plans(validPlanResponseList)
-            .build();
     }
 
     // ========== CREATE 테스트 ==========
@@ -143,6 +145,7 @@ public class PlanServiceTest {
         when(planConverter.toEntity(eq(validRequestDTO), any(User.class))).thenReturn(validPlan);
         when(planRepositoryFacade.savePlan(validPlan)).thenReturn(validPlan);
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
+        when(userRepositoryFacade.findActiveUserByUserId(userId)).thenReturn(user);
 
         // when
         PlanResponseDTO result = planService.createPlan(validRequestDTO, userId);
@@ -205,6 +208,7 @@ public class PlanServiceTest {
         when(planConverter.toEntity(eq(allDayRequest), any(User.class))).thenReturn(allDayPlan);
         when(planRepositoryFacade.savePlan(allDayPlan)).thenReturn(allDayPlan);
         when(planConverter.toEntity(allDayPlan)).thenReturn(allDayResponse);
+        when(userRepositoryFacade.findActiveUserByUserId(userId)).thenReturn(user);
 
         // when
         PlanResponseDTO result = planService.createPlan(allDayRequest, userId);
@@ -275,6 +279,7 @@ public class PlanServiceTest {
 
         doNothing().when(planValidator).validatePlanCreation(validRequestDTO);
         when(planConverter.toEntity(eq(validRequestDTO), any(User.class))).thenReturn(validPlan);
+        when(userRepositoryFacade.findActiveUserByUserId(userId)).thenReturn(user);
         when(planRepositoryFacade.savePlan(validPlan)).thenThrow(new RuntimeException("데이터베이스 오류"));
 
         // when & then
@@ -409,7 +414,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateGetPlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(independentPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, 1L)).thenReturn(
+            independentPlan);
         when(planConverter.toEntity(independentPlan)).thenReturn(independentResponse);
 
         // when
@@ -433,14 +439,14 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateGetPlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(null);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, 1L)).thenReturn(null);
 
         // when & then
         assertThatThrownBy(() -> planService.getPlanById(planId, userId))
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_NOT_FOUND);
 
-        verify(planRepositoryFacade).findActivePlanById(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, 1L);
         verify(planConverter, never()).toEntity(any(Plan.class));
     }
 
@@ -452,7 +458,7 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateGetPlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenThrow(
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, 1L)).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
@@ -469,7 +475,8 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateGetPlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         when(planConverter.toEntity(validPlan)).thenThrow(new RuntimeException("변환 오류"));
 
         // when & then
@@ -495,7 +502,7 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateGetPlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
         verify(planConverter, never()).toEntity(any(Plan.class));
     }
 
@@ -516,7 +523,7 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateGetPlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
         verify(planConverter, never()).toEntity(any(Plan.class));
     }
 
@@ -537,7 +544,7 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateGetPlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
         verify(planConverter, never()).toEntity(any(Plan.class));
     }
 
@@ -555,7 +562,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doNothing().when(planValidator).validateTitle("수정된 제목");
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class)); // 아무 DTO나 반환
@@ -603,7 +611,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
@@ -620,7 +629,7 @@ public class PlanServiceTest {
         assertThat(result.getStartDateTime()).isEqualTo(validPlan.getStartDateTime());
 
         verify(planValidator).validateUpdatePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
 
         verify(planConverter).toUpdatePlanRequestDTO(
             updateRequest,
@@ -654,7 +663,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any())).thenReturn(
             updateRequest);
         when(planConverter.toEntity(validPlan)).thenReturn(expectedResponse);
@@ -684,7 +694,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doNothing().when(planValidator).validateDateRange(newStartTime, newEndTime);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
@@ -722,7 +733,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doNothing().when(planValidator)
             .validateAllDayDateTime(true, normalizedStartTime, normalizedEndTime);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
@@ -767,7 +779,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(allDayPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            allDayPlan);
         doNothing().when(planValidator).validateAllDayDateTime(false, allDayPlan.getStartDateTime(),
             allDayPlan.getEndDateTime());
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
@@ -804,7 +817,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
@@ -847,7 +861,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(completedPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            completedPlan);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(completedPlan)).thenReturn(validResponseDTO);
@@ -889,7 +904,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doNothing().when(planValidator).validateTitle("완전히 새로운 제목");
         doNothing().when(planValidator).validateDateRange(newStartTime, newEndTime);
         doNothing().when(planValidator)
@@ -928,7 +944,7 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(null);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(null);
 
         // when & then
         assertThatThrownBy(
@@ -936,7 +952,7 @@ public class PlanServiceTest {
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_NOT_FOUND);
 
-        verify(planRepositoryFacade).findActivePlanById(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
         verify(planValidator, never()).validateTitle(any());
         verify(planConverter, never()).toUpdatePlanRequestDTO(any(), any(), any(), any());
     }
@@ -953,7 +969,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doThrow(new PlanException(PlanExceptionType.PLAN_TITLE_EMPTY))
             .when(planValidator).validateTitle("");
 
@@ -983,7 +1000,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doThrow(new PlanException(PlanExceptionType.INVALID_PLAN_DATE_RANGE))
             .when(planValidator).validateDateRange(invalidStartTime, invalidEndTime);
 
@@ -1010,7 +1028,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doThrow(new PlanException(PlanExceptionType.INVALID_PLAN_DATE_RANGE))
             .when(planValidator).validateAllDayDateTime(any(), any(), any());
 
@@ -1037,7 +1056,7 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenThrow(
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
@@ -1046,7 +1065,7 @@ public class PlanServiceTest {
             .isInstanceOf(PlanException.class)
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_UPDATE_FAILED);
 
-        verify(planRepositoryFacade).findActivePlanById(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
         verify(planConverter, never()).toUpdatePlanRequestDTO(any(), any(), any(), any());
     }
 
@@ -1062,7 +1081,8 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doNothing().when(planValidator).validateTitle("수정된 제목");
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenThrow(new RuntimeException("변환 오류"));
@@ -1084,7 +1104,8 @@ public class PlanServiceTest {
         PlanUpdateRequestDTO emptyRequest = PlanUpdateRequestDTO.builder().build();
 
         doNothing().when(planValidator).validateUpdatePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         when(planConverter.toUpdatePlanRequestDTO(any(), any(), any(), any()))
             .thenReturn(mock(PlanUpdateRequestDTO.class));
         when(planConverter.toEntity(validPlan)).thenReturn(validResponseDTO);
@@ -1118,16 +1139,17 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
+        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when
         planService.deletePlan(planId, userId);
 
         // then
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
 
@@ -1150,16 +1172,17 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(independentPlan);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            independentPlan);
+        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when
         planService.deletePlan(planId, userId);
 
         // then
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
     @Test
@@ -1182,16 +1205,17 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(completedPlan);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            completedPlan);
+        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when
         planService.deletePlan(planId, userId);
 
         // then
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
     @Test
@@ -1213,16 +1237,17 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(allDayPlan);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            allDayPlan);
+        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when
         planService.deletePlan(planId, userId);
 
         // then
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
     @Test
@@ -1233,7 +1258,7 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(null);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(null);
 
         // when & then
         assertThatThrownBy(() -> planService.deletePlan(planId, userId))
@@ -1241,8 +1266,8 @@ public class PlanServiceTest {
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_NOT_FOUND);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 
     @Test
@@ -1262,8 +1287,8 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 
     @Test
@@ -1283,8 +1308,8 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 
     @Test
@@ -1304,8 +1329,8 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 
     @Test
@@ -1316,7 +1341,7 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenThrow(
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenThrow(
             new RuntimeException("데이터베이스 조회 오류"));
 
         // when & then
@@ -1325,8 +1350,8 @@ public class PlanServiceTest {
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_DELETE_FAILED);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 
     @Test
@@ -1337,9 +1362,10 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
         doThrow(new RuntimeException("데이터베이스 삭제 오류"))
-            .when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+            .when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when & then
         assertThatThrownBy(() -> planService.deletePlan(planId, userId))
@@ -1347,8 +1373,8 @@ public class PlanServiceTest {
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_DELETE_FAILED);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
     @Test
@@ -1368,8 +1394,8 @@ public class PlanServiceTest {
                 PlanExceptionType.PLAN_INVALID_PLAN_ID);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade, never()).findActivePlanById(any());
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade, never()).findActivePlanByPlanIdAndUserId(any(), any());
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 
     @Test
@@ -1393,16 +1419,17 @@ public class PlanServiceTest {
             .build();
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(planWithSubPlans);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            planWithSubPlans);
+        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when
         planService.deletePlan(planId, userId);
 
         // then
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
     @Test
@@ -1413,8 +1440,9 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId)).thenReturn(validPlan);
-        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId)).thenReturn(
+            validPlan);
+        doNothing().when(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
 
         // when
         planService.deletePlan(planId, userId);
@@ -1422,8 +1450,8 @@ public class PlanServiceTest {
         // then - 메서드 호출 순서 검증
         InOrder inOrder = inOrder(planValidator, planRepositoryFacade);
         inOrder.verify(planValidator).validateDeletePlan(planId);
-        inOrder.verify(planRepositoryFacade).findActivePlanById(planId);
-        inOrder.verify(planRepositoryFacade).deleteActivePlanByPlanId(planId);
+        inOrder.verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        inOrder.verify(planRepositoryFacade).deleteActivePlanByPlanId(planId, userId);
     }
 
     @Test
@@ -1434,7 +1462,7 @@ public class PlanServiceTest {
         Long userId = 1L;
 
         doNothing().when(planValidator).validateDeletePlan(planId);
-        when(planRepositoryFacade.findActivePlanById(planId))
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(planId, userId))
             .thenThrow(new IllegalArgumentException("예상치 못한 오류"));
 
         // when & then
@@ -1443,7 +1471,7 @@ public class PlanServiceTest {
             .hasFieldOrPropertyWithValue("planExceptionType", PlanExceptionType.PLAN_DELETE_FAILED);
 
         verify(planValidator).validateDeletePlan(planId);
-        verify(planRepositoryFacade).findActivePlanById(planId);
-        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any());
+        verify(planRepositoryFacade).findActivePlanByPlanIdAndUserId(planId, userId);
+        verify(planRepositoryFacade, never()).deleteActivePlanByPlanId(any(), any());
     }
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/plans/service/SubPlanServiceTest.java
@@ -102,15 +102,15 @@ class SubPlanServiceTest {
             .completedAt(null)
             .build();
 
-        when(planRepositoryFacade.findActivePlanById(1L)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(1L, 1L)).thenReturn(validPlan);
         when(subPlanRepositoryFacade.saveSubPlans(List.of(validSubPlan))).thenReturn(
             List.of(validSubPlan));
-        when(subPlanConverter.toSubPlanEntityList(any(), any())).thenReturn(List.of(validSubPlan));
+        when(subPlanConverter.toEntityList(any(), any())).thenReturn(List.of(validSubPlan));
         when(subPlanConverter.toSubPlanResponseListDTO(any())).thenReturn(
             List.of(validSubPlanResponseDTO));
 
         // when
-        SubPlanCreateResponseDTO result = subPlanService.createSubPlans(1L,
+        SubPlanCreateResponseDTO result = subPlanService.createSubPlans(1L, 1L,
             validSubPlanCreateRequestDTO);
 
         // then
@@ -131,11 +131,12 @@ class SubPlanServiceTest {
     @DisplayName("소계획 생성 - PlanRepository에서 예외 발생")
     void createSubPlan_PlanRepositoryException() {
         // given
-        when(planRepositoryFacade.findActivePlanById(any())).thenThrow(
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(any(), any())).thenThrow(
             new RuntimeException("데이터베이스 오류"));
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.createSubPlans(1L, validSubPlanCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subPlanService.createSubPlans(1L, 1L, validSubPlanCreateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_CREATE_FAILED);
@@ -145,11 +146,12 @@ class SubPlanServiceTest {
     @DisplayName("소계획 생성 - Plan 조회 실패")
     void createSubPlan_PlanRepositoryNotFound() {
         // given
-        when(planRepositoryFacade.findActivePlanById(any())).thenThrow(
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(any(), any())).thenThrow(
             new SubPlanException(SubPlanExceptionType.SUB_PLAN_PLAN_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.createSubPlans(1L, validSubPlanCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subPlanService.createSubPlans(1L, 1L, validSubPlanCreateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_PLAN_NOT_FOUND);
@@ -163,7 +165,8 @@ class SubPlanServiceTest {
             .subPlans(new ArrayList<>()).build();
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.createSubPlans(1L, invalidSubPlanCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subPlanService.createSubPlans(1L, 1L, invalidSubPlanCreateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_CREATE_EMPTY);
@@ -178,7 +181,8 @@ class SubPlanServiceTest {
             .subPlans(List.of(invalidSubPlanRequestDTO)).build();
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.createSubPlans(1L, invalidSubPlanCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subPlanService.createSubPlans(1L, 1L, invalidSubPlanCreateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_TITLE_EMPTY);
@@ -195,7 +199,8 @@ class SubPlanServiceTest {
             .subPlans(List.of(invalidSubPlanRequestDTO)).build();
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.createSubPlans(1L, invalidSubPlanCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subPlanService.createSubPlans(1L, 1L, invalidSubPlanCreateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_TITLE_TOO_LONG);
@@ -207,10 +212,11 @@ class SubPlanServiceTest {
         // given
         when(subPlanRepositoryFacade.saveSubPlans(any())).thenThrow(
             new RuntimeException("데이터베이스 오류"));
-        when(planRepositoryFacade.findActivePlanById(1L)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(1L, 1L)).thenReturn(validPlan);
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.createSubPlans(1L, validSubPlanCreateRequestDTO))
+        assertThatThrownBy(
+            () -> subPlanService.createSubPlans(1L, 1L, validSubPlanCreateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_CREATE_FAILED);
@@ -220,7 +226,7 @@ class SubPlanServiceTest {
     @DisplayName("소계획 전체 조회 - planId가 null인 경우")
     void getAllSubPlans_planIdIsNull() {
         // when & then
-        assertThatThrownBy(() -> subPlanService.getAllSubPlans(null))
+        assertThatThrownBy(() -> subPlanService.getAllSubPlans(null, 1L))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
@@ -230,12 +236,12 @@ class SubPlanServiceTest {
     @DisplayName("소계획 전체 조회 - SubPlanRepository에서 조회 중 예상치 못한 오류가 발생하는 경우")
     void getAllSubPlans_SubPlanRepositoryException() {
         // given
-        when(planRepositoryFacade.findActivePlanById(1L)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(1L, 1L)).thenReturn(validPlan);
         when(subPlanRepositoryFacade.findActiveSubPlansByPlan(any())).thenThrow(
             new RuntimeException());
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.getAllSubPlans(1L))
+        assertThatThrownBy(() -> subPlanService.getAllSubPlans(1L, 1L))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_READ_FAILED);
@@ -245,68 +251,16 @@ class SubPlanServiceTest {
     @DisplayName("소계획 전체 조회 - 조회된 SubPlan이 한 건도 없는 경우")
     void getAllSubPlans_EmptySubPlanList() {
         // given
-        when(planRepositoryFacade.findActivePlanById(1L)).thenReturn(validPlan);
+        when(planRepositoryFacade.findActivePlanByPlanIdAndUserId(1L, 1L)).thenReturn(validPlan);
         when(subPlanRepositoryFacade.findActiveSubPlansByPlan(any())).thenReturn(new ArrayList<>());
         when(subPlanConverter.toSubPlanResponseListDTO(anyList())).thenReturn(new ArrayList<>());
 
         // when
-        SubPlanListResponseDTO response = subPlanService.getAllSubPlans(1L);
+        SubPlanListResponseDTO response = subPlanService.getAllSubPlans(1L, 1L);
 
         // then
         assertThat(response).isNotNull();
         assertThat(response.getSubPlans()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("소계획 단건 조회 - planId가 null인 경우")
-    void getSubPlan_planIdIsNull() {
-        // when & then
-        assertThatThrownBy(() -> subPlanService.getSubPlan(null, 1L))
-            .isInstanceOf(SubPlanException.class)
-            .hasFieldOrPropertyWithValue("subPlanExceptionType",
-                SubPlanExceptionType.SUB_PLAN_PLAN_ID_IS_NULL);
-    }
-
-    @Test
-    @DisplayName("소계획 단건 조회 - subPlanId가 null인 경우")
-    void getSubPlan_subPlanIdIsNull() {
-        // when & then
-        assertThatThrownBy(() -> subPlanService.getSubPlan(1L, null))
-            .isInstanceOf(SubPlanException.class)
-            .hasFieldOrPropertyWithValue("subPlanExceptionType",
-                SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
-    }
-
-    @Test
-    @DisplayName("소계획 단건 조회 - 해당 소계획이 주계획에 포함되지 않은 경우")
-    void getSubPlan_subPlanNotBelongToPlan() {
-        // given
-        SubPlan otherSubPlan = SubPlan.builder().subPlanId(2L).title("다른 소계획").build();
-
-        when(planRepositoryFacade.findActivePlanById(1L)).thenReturn(validPlan);
-        when(subPlanRepositoryFacade.findActiveSubPlansByPlan(validPlan)).thenReturn(
-            List.of(validSubPlan));
-        when(subPlanRepositoryFacade.findActiveSubPlanBySubPlanId(2L)).thenReturn(otherSubPlan);
-
-        // when & then
-        assertThatThrownBy(() -> subPlanService.getSubPlan(1L, 2L))
-            .isInstanceOf(SubPlanException.class)
-            .hasFieldOrPropertyWithValue("subPlanExceptionType",
-                SubPlanExceptionType.SUB_PLAN_NOT_BELONG_TO_PLAN);
-    }
-
-    @Test
-    @DisplayName("소계획 단건 조회 - 예기치 못한 예외 발생 시")
-    void getSubPlan_UnexpectedException() {
-        // given
-        when(planRepositoryFacade.findActivePlanById(1L)).thenThrow(
-            new RuntimeException("DB error"));
-
-        // when & then
-        assertThatThrownBy(() -> subPlanService.getSubPlan(1L, 1L))
-            .isInstanceOf(SubPlanException.class)
-            .hasFieldOrPropertyWithValue("subPlanExceptionType",
-                SubPlanExceptionType.SUB_PLAN_READ_FAILED);
     }
 
     @Test
@@ -323,13 +277,16 @@ class SubPlanServiceTest {
             .updatedAt(LocalDateTime.now())
             .build();
 
-        given(subPlanRepositoryFacade.findActiveSubPlanBySubPlanId(1L)).willReturn(validSubPlan);
+        when(subPlanRepositoryFacade.existsValidSubPlan(any(), any(), any())).thenReturn(true);
+
+        given(subPlanRepositoryFacade.findActiveSubPlanBySubPlanId(1L)).willReturn(
+            validSubPlan);
 
         given(subPlanConverter.toSubPlanUpdateResponseDTO(any(SubPlan.class))).willReturn(
             expectedResponse);
 
         // when
-        SubPlanUpdateResponseDTO actualResponse = subPlanService.updateSubPlan(1L,
+        SubPlanUpdateResponseDTO actualResponse = subPlanService.updateSubPlan(1L, 1L, 1L,
             updateRequestDTO);
 
         // then
@@ -345,13 +302,14 @@ class SubPlanServiceTest {
     @DisplayName("SubPlan 수정 실패 - 제목 길이 초과")
     void updateSubPlan_Fail_TitleTooLong() {
         // given
+        when(subPlanRepositoryFacade.existsValidSubPlan(any(), any(), any())).thenReturn(true);
         String longTitle = "A".repeat(201);
         SubPlanUpdateRequestDTO longTitleRequest = SubPlanUpdateRequestDTO.builder()
             .title(longTitle)
             .build();
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.updateSubPlan(1L, longTitleRequest))
+        assertThatThrownBy(() -> subPlanService.updateSubPlan(1L, 1L, 1L, longTitleRequest))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_TITLE_TOO_LONG);
@@ -361,7 +319,7 @@ class SubPlanServiceTest {
     @DisplayName("SubPlan 수정 실패 - subPlanId 가 null")
     void updateSubPlan_Fail_NullSubPlanId() {
         // when & then
-        assertThatThrownBy(() -> subPlanService.updateSubPlan(null, updateRequestDTO))
+        assertThatThrownBy(() -> subPlanService.updateSubPlan(null, 1L, 1L, updateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_ID_IS_NULL);
@@ -371,11 +329,12 @@ class SubPlanServiceTest {
     @DisplayName("SubPlan 수정 실패 - 존재하지 않는 subPlan")
     void updateSubPlan_Fail_NotFound() {
         // given
+        when(subPlanRepositoryFacade.existsValidSubPlan(any(), any(), any())).thenReturn(true);
         given(subPlanRepositoryFacade.findActiveSubPlanBySubPlanId(999L))
             .willThrow(new SubPlanException(SubPlanExceptionType.SUB_PLAN_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.updateSubPlan(999L, updateRequestDTO))
+        assertThatThrownBy(() -> subPlanService.updateSubPlan(999L, 1L, 1L, updateRequestDTO))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_NOT_FOUND);
@@ -386,10 +345,11 @@ class SubPlanServiceTest {
     void deleteSubPlan_Success() {
 
         // given
+        when(subPlanRepositoryFacade.existsValidSubPlan(any(), any(), any())).thenReturn(true);
         Long subPlanId = 1L;
 
         // when
-        subPlanService.deleteSubPlan(subPlanId);
+        subPlanService.deleteSubPlan(subPlanId, 1L, 1L);
 
         // then
         verify(subPlanRepositoryFacade).deleteActiveSubPlanBySubPlanId(subPlanId);
@@ -402,8 +362,9 @@ class SubPlanServiceTest {
         doThrow(new SubPlanException(SubPlanExceptionType.SUB_PLAN_NOT_FOUND))
             .when(subPlanRepositoryFacade)
             .deleteActiveSubPlanBySubPlanId(any());
+        when(subPlanRepositoryFacade.existsValidSubPlan(any(), any(), any())).thenReturn(true);
 
-        assertThatThrownBy(() -> subPlanService.deleteSubPlan(1L))
+        assertThatThrownBy(() -> subPlanService.deleteSubPlan(1L, 1L, 1L))
             // when & then
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
@@ -414,12 +375,14 @@ class SubPlanServiceTest {
     @Test
     @DisplayName("소계획 삭제 실패 - 내부 예외 발생")
     void deleteSubPlan_Fail_InternalError() {
+
+        when(subPlanRepositoryFacade.existsValidSubPlan(any(), any(), any())).thenReturn(true);
         doThrow(new RuntimeException())
             .when(subPlanRepositoryFacade)
             .deleteActiveSubPlanBySubPlanId(any());
 
         // when & then
-        assertThatThrownBy(() -> subPlanService.deleteSubPlan(1L))
+        assertThatThrownBy(() -> subPlanService.deleteSubPlan(1L, 1L, 1L))
             .isInstanceOf(SubPlanException.class)
             .hasFieldOrPropertyWithValue("subPlanExceptionType",
                 SubPlanExceptionType.SUB_PLAN_DELETE_FAILED);

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceTest.java
@@ -19,8 +19,12 @@ import com.hotpack.krocs.domain.templates.exception.SubTemplateException;
 import com.hotpack.krocs.domain.templates.exception.SubTemplateExceptionType;
 import com.hotpack.krocs.domain.templates.facade.SubTemplateRepositoryFacade;
 import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
+import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.domain.enums.AccountType;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.entity.Priority;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +42,8 @@ class SubTemplateServiceTest {
     @Mock
     private SubTemplateRepositoryFacade subTemplateRepositoryFacade;
     @Mock
+    private UserRepositoryFacade userRepositoryFacade;
+    @Mock
     private TemplateRepositoryFacade templateRepositoryFacade;
 
     @InjectMocks
@@ -48,11 +54,19 @@ class SubTemplateServiceTest {
     private SubTemplateUpdateRequestDTO validSubTemplateUpdateRequestDTO;
     private SubTemplate validSubTemplate;
     private Template validTemplate;
+    private User user;
 
 
     @BeforeEach
     void setup() {
         // given
+        user = User.builder()
+            .name("박성열")
+            .email("qkrtjdduf@example.com")
+            .accountId("local-" + UUID.randomUUID())
+            .accountType(AccountType.LOCAL)
+            .build();
+
         validTemplate = Template.builder()
             .templateId(1L)
             .priority(Priority.HIGH)
@@ -84,7 +98,10 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 생성 성공")
     void createSubTemplates_Success() {
         // when
-        when(templateRepositoryFacade.findActiveParentTemplateByTemplateId(1L)).thenReturn(validTemplate);
+        when(templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(1L,
+            1L)).thenReturn(
+            validTemplate);
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
         when(subTemplateRepositoryFacade.saveAll(any())).thenReturn(List.of(validSubTemplate));
 
         SubTemplateCreateResponseDTO responseDTO = subTemplateService.createSubTemplates(1L,
@@ -113,8 +130,10 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 생성 실패 - 부모 템플릿이 존재하지 않는 경우")
     void createSubTemplates_templateNotFound() {
         // given
-        when(templateRepositoryFacade.findActiveParentTemplateByTemplateId(1L))
-            .thenThrow(new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOT_FOUND));
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(1L, 1L))
+            .thenThrow(
+                new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_TEMPLATE_NOT_FOUND));
 
         // when & then
         SubTemplateException exception = assertThrows(SubTemplateException.class,
@@ -128,7 +147,9 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 생성 실패 - 예상치 못한 오류 발생")
     void createSubTemplates_UnknownException() {
         // when
-        when(templateRepositoryFacade.findActiveParentTemplateByTemplateId(1L)).thenThrow(
+        when(userRepositoryFacade.findActiveUserByUserId(1L)).thenReturn(user);
+        when(templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(1L,
+            1L)).thenThrow(
             new RuntimeException());
 
         SubTemplateException exception = assertThrows(SubTemplateException.class,
@@ -145,12 +166,14 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 전체 조회 - 성공")
     void getSubTemplates_Success() {
         // when
-        when(templateRepositoryFacade.findActiveParentTemplateByTemplateId(1L)).thenReturn(validTemplate);
+        when(templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(1L,
+            1L)).thenReturn(
+            validTemplate);
         when(
             subTemplateRepositoryFacade.findActiveSubTemplatesByTemplate(validTemplate)).thenReturn(
             List.of(validSubTemplate));
         List<SubTemplateResponseDTO> subTemplateResponseDTOs = subTemplateService.getSubTemplates(
-            1L);
+            1L, 1L);
 
         // then
         assertThat(subTemplateResponseDTOs).hasSize(1);
@@ -164,7 +187,7 @@ class SubTemplateServiceTest {
     void getSubTemplates_TemplateIdIsNull() {
 
         // when & then
-        assertThatThrownBy(() -> subTemplateService.getSubTemplates(null))
+        assertThatThrownBy(() -> subTemplateService.getSubTemplates(null, 1L))
             .isInstanceOf(SubTemplateException.class)
             .satisfies(ex -> {
                 SubTemplateException e = (SubTemplateException) ex;
@@ -176,12 +199,13 @@ class SubTemplateServiceTest {
     @Test
     @DisplayName("서브 템플릿 전체 조회 - subTemplate을 찾지 못한 경우")
     void getSubTemplates_SubTemplateNotFound() {
-        when(templateRepositoryFacade.findActiveTemplateByTemplateId(1L)).thenReturn(validTemplate);
+        when(templateRepositoryFacade.findActiveParentTemplateByTemplateIdAndUserId(1L,
+            1L)).thenReturn(validTemplate);
         when(
             subTemplateRepositoryFacade.findActiveSubTemplatesByTemplate(validTemplate)).thenReturn(
             null);
         // when & then
-        assertThatThrownBy(() -> subTemplateService.getSubTemplates(1L))
+        assertThatThrownBy(() -> subTemplateService.getSubTemplates(1L, 1L))
             .isInstanceOf(SubTemplateException.class)
             .satisfies(ex -> {
                 SubTemplateException e = (SubTemplateException) ex;
@@ -196,8 +220,9 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 삭제 - 성공")
     void deleteSubTemplate_Success() {
         // when
+        when(subTemplateRepositoryFacade.existsValidSubTemplate(1L, 1L, 1L)).thenReturn(true);
         when(subTemplateRepositoryFacade.deleteActiveSubTemplateBySubTemplateId(1L)).thenReturn(1L);
-        SubTemplateDeleteResponseDTO responseDTO = subTemplateService.deleteSubTemplate(1L);
+        SubTemplateDeleteResponseDTO responseDTO = subTemplateService.deleteSubTemplate(1L, 1L, 1L);
 
         // then
         assertThat(responseDTO.getSubTemplateId()).isEqualTo(1L);
@@ -207,11 +232,12 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 삭제 - subTemplate이 null인 경우")
     void deleteSubTemplate_subTemplateIsNull() {
         // given
+        when(subTemplateRepositoryFacade.existsValidSubTemplate(1L, 1L, 1L)).thenReturn(true);
         when(subTemplateRepositoryFacade.deleteActiveSubTemplateBySubTemplateId(1L)).thenThrow(
             new SubTemplateException(SubTemplateExceptionType.SUB_TEMPLATE_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> subTemplateService.deleteSubTemplate(1L))
+        assertThatThrownBy(() -> subTemplateService.deleteSubTemplate(1L, 1L, 1L))
             .isInstanceOf(SubTemplateException.class)
             .satisfies(ex -> {
                 SubTemplateException e = (SubTemplateException) ex;
@@ -224,7 +250,7 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 삭제 - subTemplateId가 null인 경우")
     void deleteSubTemplate_subTemplateIdIsNull() {
         // when & then
-        assertThatThrownBy(() -> subTemplateService.deleteSubTemplate(null))
+        assertThatThrownBy(() -> subTemplateService.deleteSubTemplate(null, 1L, 1L))
             .isInstanceOf(SubTemplateException.class)
             .satisfies(ex -> {
                 SubTemplateException e = (SubTemplateException) ex;
@@ -239,6 +265,7 @@ class SubTemplateServiceTest {
     @DisplayName("서브 템플릿 수정 - 성공")
     void updateSubTemplate_Success() {
         // given
+        when(subTemplateRepositoryFacade.existsValidSubTemplate(1L, 1L, 1L)).thenReturn(true);
         SubTemplate updatedSubTemplate = SubTemplate.builder()
             .subTemplateId(1L)
             .title("수정되었습니다")
@@ -249,7 +276,7 @@ class SubTemplateServiceTest {
             validSubTemplateUpdateRequestDTO)).thenReturn(updatedSubTemplate);
 
         // when
-        SubTemplateResponseDTO responseDTO = subTemplateService.updateSubTemplate(1L,
+        SubTemplateResponseDTO responseDTO = subTemplateService.updateSubTemplate(1L, 1L, 1L,
             validSubTemplateUpdateRequestDTO);
 
         // then
@@ -263,7 +290,8 @@ class SubTemplateServiceTest {
     void updateSubTemplate_subTemplateIdIsNull() {
         // when & then
         assertThatThrownBy(
-            () -> subTemplateService.updateSubTemplate(null, validSubTemplateUpdateRequestDTO))
+            () -> subTemplateService.updateSubTemplate(null, 1L, 1L,
+                validSubTemplateUpdateRequestDTO))
             .isInstanceOf(SubTemplateException.class)
             .satisfies(ex -> {
                 SubTemplateException e = (SubTemplateException) ex;
@@ -278,10 +306,12 @@ class SubTemplateServiceTest {
         // given
         when(subTemplateRepositoryFacade.updateActiveSubTemplateBySubTemplateId(1L,
             validSubTemplateUpdateRequestDTO)).thenThrow(new RuntimeException());
+        when(subTemplateRepositoryFacade.existsValidSubTemplate(1L, 1L, 1L)).thenReturn(true);
 
         // when & then
         assertThatThrownBy(
-            () -> subTemplateService.updateSubTemplate(1L, validSubTemplateUpdateRequestDTO))
+            () -> subTemplateService.updateSubTemplate(1L, 1L, 1L,
+                validSubTemplateUpdateRequestDTO))
             .isInstanceOf(SubTemplateException.class)
             .satisfies(ex -> {
                 SubTemplateException e = (SubTemplateException) ex;

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
@@ -21,11 +21,14 @@ import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.facade.TemplateRepositoryFacade;
 import com.hotpack.krocs.domain.templates.validator.TemplateValidator;
 import com.hotpack.krocs.domain.user.domain.User;
+import com.hotpack.krocs.domain.user.domain.enums.AccountType;
+import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.entity.Priority;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +43,9 @@ class TemplateServiceTest {
 
     @Mock
     private TemplateRepositoryFacade templateRepositoryFacade;
+
+    @Mock
+    private UserRepositoryFacade userRepositoryFacade;
 
     @Spy
     private TemplateValidator templateValidator = new TemplateValidator(); // 수동 생성
@@ -56,9 +62,17 @@ class TemplateServiceTest {
     private TemplateCreateResponseDTO validCreateResponseDTO;
     private TemplateResponseDTO validResponseDTO;
     private SubTemplateResponseDTO subTemplateResponseDTO;
+    private User user;
 
     @BeforeEach
     void setUp() {
+        user = User.builder()
+            .name("박성열")
+            .email("qkrtjdduf@example.com")
+            .accountId("local-" + UUID.randomUUID())
+            .accountType(AccountType.LOCAL)
+            .build();
+
         validCreateRequestDTO = TemplateCreateRequestDTO.builder()
             .title("공부 루틴")
             .priority(Priority.HIGH)
@@ -104,6 +118,7 @@ class TemplateServiceTest {
     @DisplayName("템플릿 생성 성공 테스트")
     void createTemplate_Success() {
         // given
+        when(userRepositoryFacade.findActiveUserByUserId(3L)).thenReturn(user);
         when(templateConverter.toEntity(eq(validCreateRequestDTO), any(User.class))).thenReturn(
             validTemplate);
         when(templateRepositoryFacade.save(validTemplate)).thenReturn(validTemplate);
@@ -181,8 +196,7 @@ class TemplateServiceTest {
     @DisplayName("템플릿 전체 조회 성공 - 제목 없이 조회")
     void getTemplates_Success_WithoutTitle() {
         // given
-
-        when(templateRepositoryFacade.findAllActiveTemplates())
+        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(1L))
             .thenReturn(List.of(validTemplate));
 
         when(templateConverter.toTemplateResponseDTO(validTemplate))
@@ -200,7 +214,7 @@ class TemplateServiceTest {
     @DisplayName("템플릿 검색 조회 성공 - 제목 키워드 포함")
     void getTemplates_Success_WithKeyword() {
         // when
-        when(templateRepositoryFacade.findActiveTemplatesByTitle("공부"))
+        when(templateRepositoryFacade.findActiveTemplatesByTitleAndUserId("공부", 1L))
             .thenReturn(List.of(validTemplate));
 
         when(templateConverter.toTemplateResponseDTO(validTemplate))
@@ -251,7 +265,7 @@ class TemplateServiceTest {
         when(templateConverter.toTemplateResponseDTO(updatedEntity))
             .thenReturn(validResponseDTO);
 
-        when(templateRepositoryFacade.findActiveTemplateByTemplateId(1L))
+        when(templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(1L, 1L))
             .thenReturn(existed).thenReturn(updatedEntity);
 
         // when
@@ -298,7 +312,7 @@ class TemplateServiceTest {
     @DisplayName("템플릿 수정 실패 - 존재하지 않는 템플릿")
     void updateTemplate_Fail_TemplateNotFound() {
         // when
-        when(templateRepositoryFacade.findActiveTemplateByTemplateId(1L))
+        when(templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(1L, 1L))
             .thenThrow(new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND));
 
         TemplateException exception = catchThrowableOfType(
@@ -318,7 +332,7 @@ class TemplateServiceTest {
     @DisplayName("템플릿 삭제 성공")
     void deleteTemplate_Success() {
         // when
-        when(templateRepositoryFacade.findActiveTemplateByTemplateId(1L))
+        when(templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(1L, 1L))
             .thenReturn(validTemplate);
 
         // then
@@ -333,7 +347,7 @@ class TemplateServiceTest {
     void deleteTemplate_Fail_TemplateNotFound() {
         // when
 
-        when(templateRepositoryFacade.findActiveTemplateByTemplateId(1L))
+        when(templateRepositoryFacade.findActiveTemplateByTemplateIdAndUserId(1L, 1L))
             .thenThrow(new TemplateException(TemplateExceptionType.TEMPLATE_NOT_FOUND));
 
         TemplateException exception = catchThrowableOfType(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #111 

## 🚀 작업 내용
- [x] 모든 도메인에 대하여 클라이언트의 userId를 기반으로 데이터를 조회하도록 리팩토링
- [x] 모든 Sub 도메인에 대해 컨트롤러 및 서비스 완전 분리
- [x] auth/me 죄회 정보 변경

## 🔍 리뷰 요청 사항 및 공유자료
### 공유 자료
- test용 더미데이터를 로컬 db에 저장한 뒤, 아래 리뷰를 진행해주세요!
- 더미데이터는 [여기](https://www.notion.so/KROCS-19dac07ca4e98049866afd53c95e76a6?p=262ac07ca4e980398dbcdfde2f724bd4&pm=s)에서 `init_dev_database_250921.sql`을 다운받아 주석 확인 후 실행해주세요!

### 리뷰 요청 사항
- swagger url에 대해 검수해주세요!
- userId 기반으로 조회가 잘 되는지 확인해주세요! (postman 사용해보는 것도...)
- auth/me가 잘 동작하는지, 추가했으면 하는 정보가 있는지 확인해주세요!
 
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
45분+...

test
