### PR TITLE
[feat] 탬플릿 조회 페이지 기준으로 조정

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
@@ -9,6 +9,7 @@ import com.hotpack.krocs.domain.templates.exception.TemplateException;
 import com.hotpack.krocs.domain.templates.exception.TemplateExceptionType;
 import com.hotpack.krocs.domain.templates.service.TemplateService;
 import com.hotpack.krocs.global.common.response.ApiResponse;
+import com.hotpack.krocs.global.common.response.PageResponseDTO;
 import com.hotpack.krocs.global.security.annotation.Login;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -16,6 +17,9 @@ import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,7 +60,7 @@ public class TemplateController {
         }
     }
 
-    @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
+/*    @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
     @GetMapping
     public ApiResponse<List<TemplateResponseDTO>> getTemplates(
         @Login Long userId,
@@ -64,6 +68,26 @@ public class TemplateController {
         try {
             List<TemplateResponseDTO> responseDTO = templateService.getTemplatesByUserAndTitle(
                 userId, title);
+            return ApiResponse.success(responseDTO);
+
+        } catch (TemplateException e) {
+            throw e;
+
+        } catch (Exception e) {
+            throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
+        }
+    }*/
+
+    @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
+    @GetMapping
+    public ApiResponse<PageResponseDTO<TemplateResponseDTO>> getTemplates(
+        @Login Long userId,
+        @RequestParam(required = false) String title,
+        @PageableDefault(size = 6, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable) {
+        try {
+            PageResponseDTO<TemplateResponseDTO> responseDTO = templateService.getTemplatesByUserAndTitle(
+                userId, title, pageable);
             return ApiResponse.success(responseDTO);
 
         } catch (TemplateException e) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/controller/TemplateController.java
@@ -60,24 +60,6 @@ public class TemplateController {
         }
     }
 
-/*    @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
-    @GetMapping
-    public ApiResponse<List<TemplateResponseDTO>> getTemplates(
-        @Login Long userId,
-        @RequestParam(required = false) String title) {
-        try {
-            List<TemplateResponseDTO> responseDTO = templateService.getTemplatesByUserAndTitle(
-                userId, title);
-            return ApiResponse.success(responseDTO);
-
-        } catch (TemplateException e) {
-            throw e;
-
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
-        }
-    }*/
-
     @Operation(summary = "템플릿 전체 조회 및 검색", description = "사용자 ID 기반으로 템플릿을 조회하며, title 키워드로 부분 검색이 가능합니다.")
     @GetMapping
     public ApiResponse<PageResponseDTO<TemplateResponseDTO>> getTemplates(

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/TemplateResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/dto/response/TemplateResponseDTO.java
@@ -14,8 +14,6 @@ import java.util.List;
 public class TemplateResponseDTO {
     private Long templateId;
 
-    private Long userId;
-
     private String title;
 
     private Priority priority;

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
@@ -6,6 +6,8 @@ import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,15 @@ public class TemplateRepositoryFacade {
     @Transactional
     public Template save(Template template) {
         return templateRepository.save(template);
+    }
+
+    public Page<Template> findActiveTemplatesByTitleAndUserId(String title, Long userId, Pageable pageable) {
+        return templateRepository.findTemplatesByTitleContainingIgnoreCaseAndUser_userIdAndStatus(
+            title, userId, Status.ACTIVE, pageable);
+    }
+
+    public Page<Template> findAllActiveTemplatesAndUserId(Long userId, Pageable pageable) {
+        return templateRepository.findAllTemplatesByUser_UserIdAndStatus(userId, Status.ACTIVE, pageable);
     }
 
     public List<Template> findActiveTemplatesByTitleAndUserId(String title, Long userId) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/facade/TemplateRepositoryFacade.java
@@ -34,15 +34,6 @@ public class TemplateRepositoryFacade {
         return templateRepository.findAllTemplatesByUser_UserIdAndStatus(userId, Status.ACTIVE, pageable);
     }
 
-    public List<Template> findActiveTemplatesByTitleAndUserId(String title, Long userId) {
-        return templateRepository.findTemplatesByTitleContainingIgnoreCaseAndUser_userIdAndStatus(
-            title, userId, Status.ACTIVE);
-    }
-
-    public List<Template> findAllActiveTemplatesAndUserId(Long userId) {
-        return templateRepository.findAllTemplatesByUser_UserIdAndStatus(userId, Status.ACTIVE);
-    }
-
     public Template findActiveTemplateByTemplateIdAndUserId(Long templateId, Long userId) {
         return templateRepository.findTemplateByTemplateIdAndUser_UserIdAndStatus(templateId,
             userId, Status.ACTIVE);

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/TemplateRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/TemplateRepository.java
@@ -11,11 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TemplateRepository extends JpaRepository<Template, Long> {
 
-    List<Template> findTemplatesByTitleContainingIgnoreCaseAndUser_userIdAndStatus(String title,
-        Long userId, Status status);
-
-    List<Template> findAllTemplatesByUser_UserIdAndStatus(Long userId, Status status);
-
     Template findTemplateByTemplateIdAndUser_UserIdAndStatus(Long templateId, Long userId,
         Status status);
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/TemplateRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/repository/TemplateRepository.java
@@ -3,6 +3,8 @@ package com.hotpack.krocs.domain.templates.repository;
 import com.hotpack.krocs.domain.templates.domain.Template;
 import com.hotpack.krocs.global.common.entity.Status;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +18,10 @@ public interface TemplateRepository extends JpaRepository<Template, Long> {
 
     Template findTemplateByTemplateIdAndUser_UserIdAndStatus(Long templateId, Long userId,
         Status status);
+
+    Page<Template> findTemplatesByTitleContainingIgnoreCaseAndUser_userIdAndStatus(String title,
+        Long userId, Status status, Pageable pageable);
+
+    Page<Template> findAllTemplatesByUser_UserIdAndStatus(Long userId, Status status, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateService.java
@@ -16,8 +16,6 @@ public interface TemplateService {
     PageResponseDTO<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title,
         Pageable pageable);
 
-    List<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title);
-
     TemplateResponseDTO updateTemplate(Long templateId, Long userId, TemplateUpdateRequestDTO requestDTO);
 
     void deleteTemplate(Long templateId, Long userId);

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateService.java
@@ -5,11 +5,16 @@ import com.hotpack.krocs.domain.templates.dto.request.TemplateUpdateRequestDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateCreateResponseDTO;
 import com.hotpack.krocs.domain.templates.dto.response.TemplateResponseDTO;
 
+import com.hotpack.krocs.global.common.response.PageResponseDTO;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface TemplateService {
 
     TemplateCreateResponseDTO createTemplate(TemplateCreateRequestDTO requestDTO, Long userId);
+
+    PageResponseDTO<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title,
+        Pageable pageable);
 
     List<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title);
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
@@ -75,6 +75,8 @@ public class TemplateServiceImpl implements TemplateService {
 
             return PageResponseDTO.of(dtoPage);
 
+        } catch (TemplateException e) {
+            throw e;
         } catch (Exception e) {
             throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
         }

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
@@ -14,9 +14,12 @@ import com.hotpack.krocs.domain.templates.validator.TemplateValidator;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.constant.ValidationConstants;
+import com.hotpack.krocs.global.common.response.PageResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -53,6 +56,27 @@ public class TemplateServiceImpl implements TemplateService {
             throw e;
         } catch (Exception e) {
             throw new TemplateException(TemplateExceptionType.TEMPLATE_CREATION_FAILED);
+        }
+    }
+
+    @Override
+    public PageResponseDTO<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId,
+        String title, Pageable pageable) {
+        try {
+            Page<Template> templatePage;
+            if (StringUtils.hasText(title) && title.length() <= ValidationConstants.TITLE_MAX) {
+                templatePage = templateRepositoryFacade.findActiveTemplatesByTitleAndUserId(title,
+                    userId, pageable);
+            } else {
+                templatePage = templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable);
+            }
+
+            Page<TemplateResponseDTO> dtoPage = templatePage.map(templateConverter::toTemplateResponseDTO);
+
+            return PageResponseDTO.of(dtoPage);
+
+        } catch (Exception e) {
+            throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
         }
     }
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/service/TemplateServiceImpl.java
@@ -81,28 +81,6 @@ public class TemplateServiceImpl implements TemplateService {
     }
 
     @Override
-    public List<TemplateResponseDTO> getTemplatesByUserAndTitle(Long userId, String title) {
-        try {
-
-            List<Template> templates;
-            if (StringUtils.hasText(title) && title.length() <= ValidationConstants.TITLE_MAX) {
-                templates = templateRepositoryFacade.findActiveTemplatesByTitleAndUserId(title,
-                    userId);
-            } else {
-                templates = templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId);
-            }
-
-            return templates.stream()
-                .map(templateConverter::toTemplateResponseDTO)
-                .toList();
-        } catch (TemplateException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new TemplateException(TemplateExceptionType.TEMPLATE_FOUND_FAILED);
-        }
-    }
-
-    @Override
     @Transactional
     public TemplateResponseDTO updateTemplate(Long templateId, Long userId,
         TemplateUpdateRequestDTO requestDTO) {

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/PageResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/PageResponseDTO.java
@@ -1,0 +1,39 @@
+package com.hotpack.krocs.global.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PageResponseDTO<T> {
+
+    private final List<T> content;
+    private final int pageNumber;
+    private final int pageSize;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean isLast;
+
+    @Builder
+    private PageResponseDTO(List<T> content, int pageNumber, int pageSize, long totalElements, int totalPages, boolean isLast) {
+        this.content = content;
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.isLast = isLast;
+    }
+
+    // Page 객체를 PageResponseDTO로 변환하는 정적 메소드
+    public static <T> PageResponseDTO<T> of(Page<T> page) {
+        return PageResponseDTO.<T>builder()
+            .content(page.getContent())
+            .pageNumber(page.getNumber())
+            .pageSize(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .isLast(page.isLast())
+            .build();
+    }
+}

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseCode {
     // 검증 에러
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION400", "입력값 검증 실패"),
     BAD_REQUEST_BODY(HttpStatus.BAD_REQUEST, "BAD_REQUEST_BODY400", "잘못된 데이터 타입"),
+    INVALID_SORT_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_SORT_PARAMETER400", "잘못된 정렬 기준입니다."),
 
     // 비즈니스 로직 에러
     BUSINESS_LOGIC_ERROR(HttpStatus.BAD_REQUEST, "BUSINESS400", "비즈니스 로직 오류"),

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/code/resultCode/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseCode {
     // 검증 에러
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION400", "입력값 검증 실패"),
     BAD_REQUEST_BODY(HttpStatus.BAD_REQUEST, "BAD_REQUEST_BODY400", "잘못된 데이터 타입"),
-    INVALID_SORT_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_SORT_PARAMETER400", "잘못된 정렬 기준입니다."),
+    INVALID_SORT_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_SORT_PARAMETER400", "'%s'은(는) 유효하지 않은 정렬 기준입니다."),
 
     // 비즈니스 로직 에러
     BUSINESS_LOGIC_ERROR(HttpStatus.BAD_REQUEST, "BUSINESS400", "비즈니스 로직 오류"),
@@ -31,6 +31,21 @@ public enum ErrorStatus implements BaseCode {
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "DUPLICATE409", "중복된 리소스입니다"),
     OAUTH2_SESSION_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAUTH2_500",
         "세션 직렬화에 실패했습니다.");
+
+    // 메시지를 포맷팅하는 메서드
+    public String formatMessage(Object... args) {
+        return String.format(this.message, args);
+    }
+
+    // 포맷된 메시지를 사용하여 Reason을 생성하는 메서드
+    public Reason getReasonWithArgs(Object... args) {
+        return Reason.builder()
+            .message(formatMessage(args))
+            .code(code)
+            .isSuccess(false)
+            .data("")
+            .build();
+    }
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/exception/ExceptionAdvice.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/exception/ExceptionAdvice.java
@@ -200,7 +200,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         ErrorStatus errorStatus = ErrorStatus.INVALID_SORT_PARAMETER;
 
-        String errorMessage = String.format("'%s'은(는) 유효하지 않은 정렬 기준입니다.", e.getPropertyName());
+        String errorMessage = errorStatus.formatMessage(e.getPropertyName());
 
         return handleExceptionInternalFalse(e, errorStatus, HttpHeaders.EMPTY, errorStatus.getHttpStatus(), request, errorMessage);
     }

--- a/backend/src/main/java/com/hotpack/krocs/global/common/response/exception/ExceptionAdvice.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/common/response/exception/ExceptionAdvice.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -190,6 +191,18 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         );
 
         return new ResponseEntity<>(body, headers, errorStatus.getHttpStatus());
+    }
+
+    @ExceptionHandler(value = PropertyReferenceException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePropertyReferenceException(
+        PropertyReferenceException e, WebRequest request) {
+        log.warn("잘못된 정렬 필드명입니다: {}", e.getMessage());
+
+        ErrorStatus errorStatus = ErrorStatus.INVALID_SORT_PARAMETER;
+
+        String errorMessage = String.format("'%s'은(는) 유효하지 않은 정렬 기준입니다.", e.getPropertyName());
+
+        return handleExceptionInternalFalse(e, errorStatus, HttpHeaders.EMPTY, errorStatus.getHttpStatus(), request, errorMessage);
     }
 
 

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/converter/TemplateConverterTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/converter/TemplateConverterTest.java
@@ -151,5 +151,24 @@ class TemplateConverterTest {
         assertThat(result.getSubTemplates().get(0).getTitle()).isEqualTo("소목표1");
     }
 
+    @Test
+    @DisplayName("비어있는 SubTemplate 리스트를 포함한 Template 엔티티를 응답 DTO로 변환")
+    void toCreateResponseDTO_WithEmptySubTemplates() {
+        // given
+        Template templateWithEmptyList = Template.builder()
+            .templateId(3L)
+            .title("빈 서브템플릿 템플릿")
+            .subTemplates(List.of()) // 명시적으로 비어있는 리스트
+            .build();
+
+        // when
+        TemplateCreateResponseDTO result = templateConverter.toCreateResponseDTO(templateWithEmptyList);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getSubTemplates()).isNotNull();
+        assertThat(result.getSubTemplates()).isEmpty();
+    }
+
 
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/SubTemplateServiceTest.java
@@ -214,6 +214,7 @@ class SubTemplateServiceTest {
             });
     }
 
+
     // ======= DELETE =======
 
     @Test

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
@@ -197,47 +197,93 @@ class TemplateServiceTest {
     }
 
     // ======= READ =======
+
     @Test
-    @DisplayName("템플릿 전체 조회 성공 - 제목 없이 조회")
-    void getTemplates_Success_WithoutTitle() {
+    @DisplayName("템플릿 페이지네이션 조회 성공 - 검색어 없이 전체 조회")
+    void getTemplates_Pagination_Success_WithoutTitle() {
         // given
-        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(1L))
-            .thenReturn(List.of(validTemplate));
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 5); // 0번 페이지, 5개씩
+        List<Template> templateList = List.of(validTemplate);
+        Page<Template> templatePage = new PageImpl<>(templateList, pageable, 1);
 
-        when(templateConverter.toTemplateResponseDTO(validTemplate))
-            .thenReturn(validResponseDTO);
+        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
+            .thenReturn(templatePage);
 
         // when
-        List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, null);
+        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
 
         // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTitle()).isEqualTo("공부 루틴");
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getPageNumber()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.isLast()).isTrue();
     }
 
     @Test
-    @DisplayName("템플릿 검색 조회 성공 - 제목 키워드 포함")
-    void getTemplates_Success_WithKeyword() {
-        // when
-        when(templateRepositoryFacade.findActiveTemplatesByTitleAndUserId("공부", 1L))
-            .thenReturn(List.of(validTemplate));
+    @DisplayName("템플릿 페이지네이션 조회 성공 - 제목 키워드로 검색")
+    void getTemplates_Pagination_Success_WithKeyword() {
+        // given
+        Long userId = 1L;
+        String keyword = "공부";
+        Pageable pageable = PageRequest.of(0, 5);
+        List<Template> templateList = List.of(validTemplate);
+        Page<Template> templatePage = new PageImpl<>(templateList, pageable, 1);
 
-        when(templateConverter.toTemplateResponseDTO(validTemplate))
-            .thenReturn(validResponseDTO);
+        when(templateRepositoryFacade.findActiveTemplatesByTitleAndUserId(keyword, userId, pageable))
+            .thenReturn(templatePage);
+
+        // when
+        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, keyword, pageable);
 
         // then
-        List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, "공부");
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getTitle()).contains("공부");
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        // Converter가 DTO로 잘 변환했는지도 확인 (필요시)
+        // assertThat(result.getContent().get(0).getTitle()).isEqualTo(validTemplate.getTitle());
     }
 
     @Test
-    @DisplayName("템플릿 검색 조회 - 결과가 없는 경우")
-    void getTemplates_EmptyResult() {
+    @DisplayName("템플릿 페이지네이션 조회 - 검색 결과가 없는 경우 빈 리스트 반환")
+    void getTemplates_Pagination_EmptyResult() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<Template> emptyPage = Page.empty(pageable); // 비어있는 Page 객체 생성
+
+        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
+            .thenReturn(emptyPage);
+
+        // when
+        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
 
         // then
-        List<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(1L, "운동");
-        assertThat(result).isEmpty();
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty(); // content가 비어있는지 확인
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("템플릿 페이지네이션 조회 - 범위를 벗어난 페이지 요청 시 빈 리스트 반환")
+    void getTemplates_Pagination_PageOutOfRange() {
+        // given
+        Long userId = 1L;
+        // 총 1페이지(5개 데이터)만 있는데, 10번 페이지를 요청하는 상황
+        Pageable pageable = PageRequest.of(10, 5);
+        Page<Template> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 5); // content는 비어있지만, totalElements는 5
+
+        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
+            .thenReturn(emptyPage);
+
+        // when
+        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty(); // content는 비어있어야 함
+        assertThat(result.getTotalElements()).isEqualTo(5); // 하지만 총 개수는 올바르게 나와야 함
+        assertThat(result.getPageNumber()).isEqualTo(10); // 요청한 페이지 번호가 그대로 반영되어야 함
     }
 
     // ======= UPDATE =======
@@ -365,51 +411,5 @@ class TemplateServiceTest {
         assertThat(exception.getTemplateExceptionType()).isEqualTo(
             TemplateExceptionType.TEMPLATE_NOT_FOUND);
     }
-
-    // ======= READ (PAGINATION) =======
-
-    @Test
-    @DisplayName("템플릿 페이지네이션 조회 성공 - 결과가 있을 경우")
-    void getTemplates_Pagination_Success() {
-        // given
-        Long userId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        List<Template> templateList = List.of(validTemplate);
-        Page<Template> templatePage = new PageImpl<>(templateList, pageable, 1);
-
-        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
-            .thenReturn(templatePage);
-
-        // when
-        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getPageNumber()).isEqualTo(0);
-        assertThat(result.getTotalElements()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("템플릿 페이지네이션 조회 성공 - 결과가 없는 경우")
-    void getTemplates_Pagination_EmptyResult() {
-        // given
-        Long userId = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<Template> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
-
-        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
-            .thenReturn(emptyPage);
-
-        // when
-        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).isEmpty();
-        assertThat(result.getTotalElements()).isEqualTo(0);
-    }
-
-
 
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/templates/service/TemplateServiceTest.java
@@ -24,6 +24,7 @@ import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.domain.enums.AccountType;
 import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
 import com.hotpack.krocs.global.common.entity.Priority;
+import com.hotpack.krocs.global.common.response.PageResponseDTO;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,6 +38,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class TemplateServiceTest {
@@ -360,6 +365,51 @@ class TemplateServiceTest {
         assertThat(exception.getTemplateExceptionType()).isEqualTo(
             TemplateExceptionType.TEMPLATE_NOT_FOUND);
     }
+
+    // ======= READ (PAGINATION) =======
+
+    @Test
+    @DisplayName("템플릿 페이지네이션 조회 성공 - 결과가 있을 경우")
+    void getTemplates_Pagination_Success() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Template> templateList = List.of(validTemplate);
+        Page<Template> templatePage = new PageImpl<>(templateList, pageable, 1);
+
+        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
+            .thenReturn(templatePage);
+
+        // when
+        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getPageNumber()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("템플릿 페이지네이션 조회 성공 - 결과가 없는 경우")
+    void getTemplates_Pagination_EmptyResult() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Template> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+        when(templateRepositoryFacade.findAllActiveTemplatesAndUserId(userId, pageable))
+            .thenReturn(emptyPage);
+
+        // when
+        PageResponseDTO<TemplateResponseDTO> result = templateService.getTemplatesByUserAndTitle(userId, null, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
 
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #128

## 🚀 작업 내용
- [x] 기존 template 조회 코드 삭제
- [x] PageRequestDTO Page domain을 활용해서 커스텀, repository 단계에서부터 리턴하도록 수정
- 관련 테스트 코드 수정

## 🔍 리뷰 요청 사항 및 공유자료
 Page 이용해서 기본값 6개씩 페이지 조회하도록 수정함.  
 반드시 size를 늘리고, sort에 [] 괄호를 없애고 테스트 할것 
```
{
  "page": 0,
  "size": 6,
  "sort":
    "duration,desc" // 또는 "createAt,asc" 등등으로 테스트 가능
}
```
 
 1. 아무것도 보내지 않았을떄 모든 template 조회하면서 page 0, size 6이 적용되는지
 2. title 검색이 잘 적용되는지
 3. "sort":"createAt,desc" 으로 최신순 정렬이 가능한지
 4. 개체가 6개이고 개수가 그 이하일때 page 3,4등등 이상이면 빈 리스트가 반환되는지
 
```
{
  "page": 0,
  "size": 1,
  "sort": [
    "string" <<< 이부분은 정렬 관련 내용인데, 이후에 "CreatedAt" : desc 식으로 최신순 정렬, 오래된순, 중요도 정렬 등 가능함 지금은 생략해도 무관!
  ]
}
```
```

{
  "isSuccess": true,
  "code": "string",
  "message": "string",
  "result": {
    "content": [
      {
        "templateId": 0,
        "userId": 0,
        "title": "string",
        "priority": "LOW",
        "duration": 0,
        "createdAt": "2025-09-25T09:34:45.692Z",
        "updatedAt": "2025-09-25T09:34:45.692Z",
        "subTemplates": [
          {
            "title": "string",
            "sub_template_id": 0,
            "template_id": 0,
            "created_at": "2025-08-03T15:05:12",
            "updated_at": "2025-08-03T15:05:12"
          }
        ]
      }
    ],
    "pageNumber": 0, << 현재 페이지
    "pageSize": 0, << 페이지에 몇개 들어가는지 (우리는 기본값 6)
    "totalElements": 0, << 전체 개수
    "totalPages": 0, << 전체 페이지 수
    "last": true << 마지막 페이지인가? (boolean)
  }
}

```

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
15분 +
