### PR TITLE
[fix] swagger cors 에러 해결

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hotpack/krocs/global/config/SecurityConfig.java
@@ -39,6 +39,8 @@ public class SecurityConfig {
 
     @Value("${frontOrigin}")
     private String frontOrigin;
+    @Value("${baseUrl}")
+    private String baseUrl;
 
     @Bean
     public AuthenticationManager authenticationManager() {
@@ -87,7 +89,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(frontOrigin));
+        config.setAllowedOrigins(List.of(frontOrigin, baseUrl));
         config.setAllowCredentials(true);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #157 

## 📝 수정 요약
<!-- 먼저 버그에 대한 간단한 설명을 적어주세요 -->
swagger에서 get요청을 제외한 나머지 요청이 배포중인 서버에서 cors에러가 발생함

- 🚨 문제점
    - swagger에서 get요청을 제외한 나머지 요청이 배포중인 서버에서 cors에러가 발생함

- 🔍 원인 분석
    - 허용 오리진에 백엔드 주소가 허용되지 않아있었음.

- 💡 해결 방법
    - `config.setAllowedOrigins(List.of(frontOrigin, baseUrl));`로 변경

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)
@soheeGit @gawoooon 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
3분