### PR TITLE
[feat] 회고 마이페이지 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/controller/RetrospectiveController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/controller/RetrospectiveController.java
@@ -3,6 +3,7 @@ package com.hotpack.krocs.domain.retrospectives.controller;
 import com.hotpack.krocs.domain.retrospectives.dto.request.RetrospectiveCreateRequestDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.AllFactorsResponseDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveCreateResponseDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveMyPageResponseDTO;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveException;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveExceptionType;
 import com.hotpack.krocs.domain.retrospectives.service.RetrospectiveService;
@@ -14,6 +15,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -35,7 +41,7 @@ public class RetrospectiveController {
 
     @Operation(summary = "전체 회고 요인 목록 조회", description = "회고 시 선택 가능한 모든 성공/실패 요인 목록을 조회합니다.")
     @GetMapping("/factors")
-    public ApiResponse<AllFactorsResponseDTO> getAllFactors( @Parameter(hidden = true) @Login Long userId ) {
+    public ApiResponse<AllFactorsResponseDTO> getAllFactors(@Parameter(hidden = true) @Login Long userId) {
         try {
             AllFactorsResponseDTO response = retrospectiveService.getFactors();
             return ApiResponse.success(response);
@@ -46,16 +52,37 @@ public class RetrospectiveController {
         }
     }
 
+    @Operation(summary = "회고 마이페이지 조회", description = "사용자 본인의 회고 통계와 회고 목록을 조회합니다. outcome 값으로 특정 결과만 필터링할 수 있습니다.")
+    @GetMapping("/mypage")
+    public ApiResponse<RetrospectiveMyPageResponseDTO> getRetrospectiveMyPage(
+            @Parameter(hidden = true) @Login Long userId,
+            @Parameter(description = "회고 결과 필터 (COMPLETE_SUCCESS, COMPLETE_FAILURE, RETRY_FAILURE)", example = "COMPLETE_SUCCESS")
+            @RequestParam(name = "outcome", required = false) String outcome,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            @ParameterObject Pageable pageable
+    ) {
+        try {
+            RetrospectiveMyPageResponseDTO response = retrospectiveService.getMyPageRetrospectives(
+                    userId, outcome, pageable);
+            return ApiResponse.success(response);
+        } catch (RetrospectiveException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RetrospectiveException(RetrospectiveExceptionType.RETRO_MYPAGE_FETCH_FAILED);
+        }
+    }
+
     @Operation(summary = "대목표 완료 및 회고 제출", description = "대목표를 완료/재시도 처리하고 회고를 생성합니다.")
     @PostMapping("/goals/{goalId}")
     public ApiResponse<RetrospectiveCreateResponseDTO> createRetrospective(
-        @Parameter(hidden = true) @Login Long userId,
-        @Parameter(description = "목표 ID", example = "1")
-        @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
-        @Valid @RequestBody RetrospectiveCreateRequestDTO requestDTO
+            @Parameter(hidden = true) @Login Long userId,
+            @Parameter(description = "목표 ID", example = "1")
+            @PathVariable @Positive(message = "{common.id.positive}") Long goalId,
+            @Valid @RequestBody RetrospectiveCreateRequestDTO requestDTO
     ) {
         try {
-            RetrospectiveCreateResponseDTO response = retrospectiveService.createRetrospective(userId, goalId, requestDTO);
+            RetrospectiveCreateResponseDTO response = retrospectiveService.createRetrospective(userId, goalId,
+                    requestDTO);
             return ApiResponse.success(response);
         } catch (RetrospectiveException e) {
             throw e;
@@ -67,11 +94,11 @@ public class RetrospectiveController {
     @Operation(summary = "대목표 회고 삭제", description = "특정 대목표에 작성된 회고를 삭제합니다.")
     @DeleteMapping("/goals/{goalId}/{retroId}")
     public ApiResponse<Void> deleteRetrospective(
-        @Parameter(hidden = true) @Login Long userId,
-        @Parameter(description = "회고를 삭제할 목표 ID", example = "1")
-        @PathVariable @Positive Long goalId,
-        @Parameter(description = "삭제할 회고 ID", example = "1")
-        @PathVariable @Positive Long retroId
+            @Parameter(hidden = true) @Login Long userId,
+            @Parameter(description = "회고를 삭제할 목표 ID", example = "1")
+            @PathVariable @Positive Long goalId,
+            @Parameter(description = "삭제할 회고 ID", example = "1")
+            @PathVariable @Positive Long retroId
     ) {
         try {
             retrospectiveService.deleteRetrospective(userId, goalId, retroId);

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/converter/RetrospectiveConverter.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/converter/RetrospectiveConverter.java
@@ -1,7 +1,5 @@
 package com.hotpack.krocs.domain.retrospectives.converter;
 
-import static java.util.stream.Collectors.toList;
-
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.retrospectives.dto.response.AllFactorsResponseDTO;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveException;
@@ -14,8 +12,13 @@ import com.hotpack.krocs.domain.retrospectives.domain.SuccessFactor;
 import com.hotpack.krocs.domain.retrospectives.dto.request.RetrospectiveCreateRequestDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.FactorDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveCreateResponseDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveFactorStatisticsDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveStatisticsDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveSummaryDTO;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -109,6 +112,76 @@ public class RetrospectiveConverter {
                 }
             })
             .toList();
+    }
+
+    public RetrospectiveSummaryDTO toRetrospectiveSummaryDTO(Retrospective retrospective) {
+        List<String> factors = retrospective.getFactors() == null
+            ? List.of()
+            : List.copyOf(retrospective.getFactors());
+
+        return RetrospectiveSummaryDTO.builder()
+            .retrospectiveId(retrospective.getRetrospectiveId())
+            .goalId(retrospective.getGoal().getGoalId())
+            .goalName(retrospective.getGoal().getTitle())
+            .outcome(retrospective.getOutcome())
+            .content(retrospective.getContent())
+            .factors(factors)
+            .createdAt(retrospective.getCreatedAt())
+            .build();
+    }
+
+    public RetrospectiveStatisticsDTO toStatisticsDTO(List<Retrospective> retrospectives) {
+        Map<String, Long> successFactorCounts = new HashMap<>();
+        Map<String, Long> failureFactorCounts = new HashMap<>();
+
+        retrospectives.forEach(retrospective -> {
+            List<String> factors = retrospective.getFactors();
+            if (factors == null || factors.isEmpty()) {
+                return;
+            }
+
+            Map<String, Long> targetMap = isSuccessOutcome(retrospective.getOutcome())
+                ? successFactorCounts
+                : failureFactorCounts;
+            factors.forEach(factor -> targetMap.merge(factor, 1L, Long::sum));
+        });
+
+        return RetrospectiveStatisticsDTO.builder()
+            .topSuccessFactors(buildTopFactors(successFactorCounts, true))
+            .topFailureFactors(buildTopFactors(failureFactorCounts, false))
+            .build();
+    }
+
+    private boolean isSuccessOutcome(RetrospectiveOutcome outcome) {
+        return outcome == RetrospectiveOutcome.COMPLETE_SUCCESS;
+    }
+
+    private List<RetrospectiveFactorStatisticsDTO> buildTopFactors(Map<String, Long> factorCounts,
+        boolean isSuccessType) {
+        return factorCounts.entrySet().stream()
+            .sorted((entry1, entry2) -> {
+                int compare = Long.compare(entry2.getValue(), entry1.getValue());
+                if (compare == 0) {
+                    return entry1.getKey().compareTo(entry2.getKey());
+                }
+                return compare;
+            })
+            .limit(3)
+            .map(entry -> toFactorStatisticsDTO(entry.getKey(), entry.getValue(), isSuccessType))
+            .toList();
+    }
+
+    private RetrospectiveFactorStatisticsDTO toFactorStatisticsDTO(String factorKey, long count,
+        boolean isSuccessType) {
+        String description = isSuccessType
+            ? SuccessFactor.valueOf(factorKey).getDescription()
+            : FailureFactor.valueOf(factorKey).getDescription();
+
+        return RetrospectiveFactorStatisticsDTO.builder()
+            .factor(factorKey)
+            .description(description)
+            .count(count)
+            .build();
     }
 
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveFactorStatisticsDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveFactorStatisticsDTO.java
@@ -1,0 +1,16 @@
+package com.hotpack.krocs.domain.retrospectives.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RetrospectiveFactorStatisticsDTO {
+
+    private final String factor;
+    private final String description;
+    private final long count;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveMyPageResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveMyPageResponseDTO.java
@@ -1,0 +1,16 @@
+package com.hotpack.krocs.domain.retrospectives.dto.response;
+
+import com.hotpack.krocs.global.common.response.PageResponseDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RetrospectiveMyPageResponseDTO {
+
+    private final RetrospectiveStatisticsDTO statistics;
+    private final PageResponseDTO<RetrospectiveSummaryDTO> retrospectives;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveStatisticsDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveStatisticsDTO.java
@@ -1,0 +1,16 @@
+package com.hotpack.krocs.domain.retrospectives.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RetrospectiveStatisticsDTO {
+
+    private final List<RetrospectiveFactorStatisticsDTO> topSuccessFactors;
+    private final List<RetrospectiveFactorStatisticsDTO> topFailureFactors;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveSummaryDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/dto/response/RetrospectiveSummaryDTO.java
@@ -1,0 +1,26 @@
+package com.hotpack.krocs.domain.retrospectives.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hotpack.krocs.domain.retrospectives.domain.RetrospectiveOutcome;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RetrospectiveSummaryDTO {
+
+    private final Long retrospectiveId;
+    private final Long goalId;
+    private final String goalName;
+    private final RetrospectiveOutcome outcome;
+    private final String content;
+    private final List<String> factors;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/exception/RetrospectiveExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/exception/RetrospectiveExceptionType.java
@@ -19,7 +19,8 @@ public enum RetrospectiveExceptionType implements BaseCode {
 
     RETRO_NOT_FOUND(HttpStatus.NOT_FOUND, "RETRO404", "삭제할 회고를 찾을 수 없습니다."),
     RETRO_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RETRO500", "회고 삭제에 실패했습니다."),
-    RETRO_GETFACTORS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RETRO500", "요소 리스트 조회에 실패했습니다.");
+    RETRO_GETFACTORS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RETRO500", "요소 리스트 조회에 실패했습니다."),
+    RETRO_MYPAGE_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RETRO500", "회고 마이페이지 조회에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/facade/RetrospectiveRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/facade/RetrospectiveRepositoryFacade.java
@@ -3,12 +3,16 @@ package com.hotpack.krocs.domain.retrospectives.facade;
 
 import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.retrospectives.domain.Retrospective;
+import com.hotpack.krocs.domain.retrospectives.domain.RetrospectiveOutcome;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveException;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveExceptionType;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.global.common.entity.Status;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +36,19 @@ public class RetrospectiveRepositoryFacade {
             throw new RetrospectiveException(RetrospectiveExceptionType.RETRO_NOT_FOUND);
         }
         return retro;
+    }
+
+    public Page<Retrospective> findRetrospectivesByUser(User user, Pageable pageable) {
+        return retroRespository.findByUserAndStatus(user, Status.ACTIVE, pageable);
+    }
+
+    public Page<Retrospective> findRetrospectivesByUserAndOutcome(User user, RetrospectiveOutcome outcome,
+        Pageable pageable) {
+        return retroRespository.findByUserAndOutcomeAndStatus(user, outcome, Status.ACTIVE, pageable);
+    }
+
+    public List<Retrospective> findAllActiveRetrospectivesByUser(User user) {
+        return retroRespository.findAllByUserAndStatus(user, Status.ACTIVE);
     }
 
     public void delete(Retrospective retrospective) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/facade/RetrospectiveRespository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/facade/RetrospectiveRespository.java
@@ -1,8 +1,12 @@
 package com.hotpack.krocs.domain.retrospectives.facade;
 
 import com.hotpack.krocs.domain.retrospectives.domain.Retrospective;
+import com.hotpack.krocs.domain.retrospectives.domain.RetrospectiveOutcome;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.global.common.entity.Status;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +15,11 @@ public interface RetrospectiveRespository extends JpaRepository<Retrospective, L
 
     Retrospective findRetrospectiveByUserAndRetrospectiveIdAndStatus(User user,
         Long retrospectiveId, Status status);
+
+    Page<Retrospective> findByUserAndStatus(User user, Status status, Pageable pageable);
+
+    Page<Retrospective> findByUserAndOutcomeAndStatus(User user, RetrospectiveOutcome outcome,
+        Status status, Pageable pageable);
+
+    List<Retrospective> findAllByUserAndStatus(User user, Status status);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/service/RetrospectiveService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/service/RetrospectiveService.java
@@ -2,9 +2,9 @@ package com.hotpack.krocs.domain.retrospectives.service;
 
 import com.hotpack.krocs.domain.retrospectives.dto.request.RetrospectiveCreateRequestDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.AllFactorsResponseDTO;
-import com.hotpack.krocs.domain.retrospectives.dto.response.FactorDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveCreateResponseDTO;
-import java.util.List;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveMyPageResponseDTO;
+import org.springframework.data.domain.Pageable;
 
 public interface RetrospectiveService {
 
@@ -13,4 +13,6 @@ public interface RetrospectiveService {
     RetrospectiveCreateResponseDTO createRetrospective(Long userId, Long goalId, RetrospectiveCreateRequestDTO requestDTO);
 
     AllFactorsResponseDTO getFactors ();
+
+    RetrospectiveMyPageResponseDTO getMyPageRetrospectives(Long userId, String outcome, Pageable pageable);
 }

--- a/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/service/RetrospectiveServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/retrospectives/service/RetrospectiveServiceImpl.java
@@ -9,16 +9,21 @@ import com.hotpack.krocs.domain.retrospectives.domain.Retrospective;
 import com.hotpack.krocs.domain.retrospectives.domain.RetrospectiveOutcome;
 import com.hotpack.krocs.domain.retrospectives.dto.request.RetrospectiveCreateRequestDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.AllFactorsResponseDTO;
-import com.hotpack.krocs.domain.retrospectives.dto.response.FactorDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveCreateResponseDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveMyPageResponseDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveStatisticsDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveSummaryDTO;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveException;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveExceptionType;
 import com.hotpack.krocs.domain.retrospectives.facade.RetrospectiveRepositoryFacade;
 import com.hotpack.krocs.domain.retrospectives.validator.RetrospectiveValidator;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
+import com.hotpack.krocs.global.common.response.PageResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,6 +76,44 @@ public class RetrospectiveServiceImpl implements RetrospectiveService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public RetrospectiveMyPageResponseDTO getMyPageRetrospectives(Long userId, String outcome,
+        Pageable pageable) {
+        try {
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new RetrospectiveException(RetrospectiveExceptionType.RETRO_USER_NOT_FOUND);
+            }
+
+            RetrospectiveOutcome filterOutcome = parseOutcome(outcome);
+            Page<Retrospective> retrospectivePage =
+                filterOutcome == null
+                    ? retrospectiveRepositoryFacade.findRetrospectivesByUser(user, pageable)
+                    : retrospectiveRepositoryFacade.findRetrospectivesByUserAndOutcome(user,
+                        filterOutcome, pageable);
+
+            Page<RetrospectiveSummaryDTO> summaryPage = retrospectivePage.map(
+                retrospectiveConverter::toRetrospectiveSummaryDTO);
+            PageResponseDTO<RetrospectiveSummaryDTO> retrospectives = PageResponseDTO.of(
+                summaryPage);
+
+            List<Retrospective> allRetrospectives = retrospectiveRepositoryFacade.findAllActiveRetrospectivesByUser(
+                user);
+            RetrospectiveStatisticsDTO statistics = retrospectiveConverter.toStatisticsDTO(
+                allRetrospectives);
+
+            return RetrospectiveMyPageResponseDTO.builder()
+                .statistics(statistics)
+                .retrospectives(retrospectives)
+                .build();
+        } catch (RetrospectiveException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RetrospectiveException(RetrospectiveExceptionType.RETRO_MYPAGE_FETCH_FAILED);
+        }
+    }
+
+    @Override
     @Transactional
     public void deleteRetrospective(Long userId, Long goalId, Long retroId) {
         try {
@@ -93,6 +136,17 @@ public class RetrospectiveServiceImpl implements RetrospectiveService {
             throw e;
         } catch (Exception e) {
             throw new RetrospectiveException(RetrospectiveExceptionType.RETRO_DELETE_FAILED);
+        }
+    }
+
+    private RetrospectiveOutcome parseOutcome(String outcome) {
+        if (outcome == null || outcome.isBlank()) {
+            return null;
+        }
+        try {
+            return RetrospectiveOutcome.valueOf(outcome.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new RetrospectiveException(RetrospectiveExceptionType.RETRO_INVALID_OUTCOME_KEY);
         }
     }
 

--- a/backend/src/test/java/com/hotpack/krocs/domain/retrospectives/service/RetrospectiveServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/retrospectives/service/RetrospectiveServiceTest.java
@@ -9,14 +9,19 @@ import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.retrospectives.converter.RetrospectiveConverter;
 import com.hotpack.krocs.domain.retrospectives.domain.Retrospective;
+import com.hotpack.krocs.domain.retrospectives.domain.RetrospectiveOutcome;
 import com.hotpack.krocs.domain.retrospectives.dto.request.RetrospectiveCreateRequestDTO;
 import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveCreateResponseDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveMyPageResponseDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveStatisticsDTO;
+import com.hotpack.krocs.domain.retrospectives.dto.response.RetrospectiveSummaryDTO;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveException;
 import com.hotpack.krocs.domain.retrospectives.exception.RetrospectiveExceptionType;
 import com.hotpack.krocs.domain.retrospectives.facade.RetrospectiveRepositoryFacade;
 import com.hotpack.krocs.domain.retrospectives.validator.RetrospectiveValidator;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.domain.user.facade.UserRepositoryFacade;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +31,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RetrospectiveServiceImpl 단위 테스트")
@@ -399,6 +408,128 @@ class RetrospectiveServiceTest {
                 () -> retrospectiveService.deleteRetrospective(userId, goalId, retroId));
 
             assertThat(ex.getErrorCode()).isEqualTo(RetrospectiveExceptionType.RETRO_DELETE_FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyPageRetrospectives 테스트")
+    class GetMyPageRetrospectives {
+
+        private final Pageable pageable = PageRequest.of(0, 20);
+
+        @Test
+        @DisplayName("성공: outcome 미지정 시 전체 회고 목록과 통계 반환")
+        void getMyPage_withoutOutcome_returnsAllRetros() {
+            // given
+            Retrospective retrospective = Retrospective.builder().retrospectiveId(1L).build();
+            Page<Retrospective> retroPage = new PageImpl<>(List.of(retrospective), pageable, 1);
+
+            RetrospectiveSummaryDTO summaryDTO = RetrospectiveSummaryDTO.builder()
+                .retrospectiveId(1L)
+                .goalId(goalId)
+                .goalName("My Goal")
+                .outcome(RetrospectiveOutcome.COMPLETE_SUCCESS)
+                .content("content")
+                .factors(List.of("CLEAR_PLAN"))
+                .createdAt(null)
+                .build();
+
+            RetrospectiveStatisticsDTO statisticsDTO = RetrospectiveStatisticsDTO.builder()
+                .topSuccessFactors(Collections.emptyList())
+                .topFailureFactors(Collections.emptyList())
+                .build();
+
+            when(userRepository.findActiveUserByUserId(userId)).thenReturn(validUser);
+            when(retrospectiveRepositoryFacade.findRetrospectivesByUser(validUser, pageable)).thenReturn(
+                retroPage);
+            when(retrospectiveConverter.toRetrospectiveSummaryDTO(any(Retrospective.class))).thenReturn(
+                summaryDTO);
+            when(retrospectiveRepositoryFacade.findAllActiveRetrospectivesByUser(validUser)).thenReturn(
+                List.of(retrospective));
+            when(retrospectiveConverter.toStatisticsDTO(anyList())).thenReturn(statisticsDTO);
+
+            // when
+            RetrospectiveMyPageResponseDTO response = retrospectiveService.getMyPageRetrospectives(
+                userId, null, pageable);
+
+            // then
+            assertThat(response.getRetrospectives().getContent()).containsExactly(summaryDTO);
+            assertThat(response.getStatistics()).isEqualTo(statisticsDTO);
+            verify(retrospectiveRepositoryFacade).findRetrospectivesByUser(validUser, pageable);
+            verify(retrospectiveRepositoryFacade, never()).findRetrospectivesByUserAndOutcome(any(),
+                any(), any());
+        }
+
+        @Test
+        @DisplayName("성공: outcome 파라미터 지정 시 해당 결과만 조회")
+        void getMyPage_withOutcome_filtersByOutcome() {
+            // given
+            Pageable pageable = PageRequest.of(0, 5);
+            Retrospective retrospective = Retrospective.builder().retrospectiveId(2L).build();
+            Page<Retrospective> retroPage = new PageImpl<>(List.of(retrospective), pageable, 1);
+
+            RetrospectiveSummaryDTO summaryDTO = RetrospectiveSummaryDTO.builder()
+                .retrospectiveId(2L)
+                .goalId(goalId)
+                .goalName("Filtered Goal")
+                .outcome(RetrospectiveOutcome.COMPLETE_SUCCESS)
+                .content(null)
+                .factors(List.of("CLEAR_PLAN"))
+                .createdAt(null)
+                .build();
+
+            RetrospectiveStatisticsDTO statisticsDTO = RetrospectiveStatisticsDTO.builder()
+                .topSuccessFactors(Collections.emptyList())
+                .topFailureFactors(Collections.emptyList())
+                .build();
+
+            when(userRepository.findActiveUserByUserId(userId)).thenReturn(validUser);
+            when(retrospectiveRepositoryFacade.findRetrospectivesByUserAndOutcome(validUser,
+                RetrospectiveOutcome.COMPLETE_SUCCESS, pageable)).thenReturn(retroPage);
+            when(retrospectiveConverter.toRetrospectiveSummaryDTO(any(Retrospective.class))).thenReturn(
+                summaryDTO);
+            when(retrospectiveRepositoryFacade.findAllActiveRetrospectivesByUser(validUser)).thenReturn(
+                List.of(retrospective));
+            when(retrospectiveConverter.toStatisticsDTO(anyList())).thenReturn(statisticsDTO);
+
+            // when
+            RetrospectiveMyPageResponseDTO response = retrospectiveService.getMyPageRetrospectives(
+                userId, "COMPLETE_SUCCESS", pageable);
+
+            // then
+            assertThat(response.getRetrospectives().getContent()).containsExactly(summaryDTO);
+            verify(retrospectiveRepositoryFacade).findRetrospectivesByUserAndOutcome(validUser,
+                RetrospectiveOutcome.COMPLETE_SUCCESS, pageable);
+            verify(retrospectiveRepositoryFacade, never()).findRetrospectivesByUser(validUser,
+                pageable);
+        }
+
+        @Test
+        @DisplayName("실패: outcome 값이 잘못되면 RETRO_INVALID_OUTCOME_KEY 발생")
+        void getMyPage_invalidOutcome_throwsException() {
+            // given
+            when(userRepository.findActiveUserByUserId(userId)).thenReturn(validUser);
+
+            // when & then
+            RetrospectiveException ex = assertThrows(RetrospectiveException.class,
+                () -> retrospectiveService.getMyPageRetrospectives(userId, "INVALID", pageable));
+
+            assertThat(ex.getErrorCode()).isEqualTo(
+                RetrospectiveExceptionType.RETRO_INVALID_OUTCOME_KEY);
+        }
+
+        @Test
+        @DisplayName("실패: 사용자 정보를 찾지 못하면 RETRO_USER_NOT_FOUND 발생")
+        void getMyPage_userNotFound() {
+            // given
+            when(userRepository.findActiveUserByUserId(userId)).thenReturn(null);
+
+            // when & then
+            RetrospectiveException ex = assertThrows(RetrospectiveException.class,
+                () -> retrospectiveService.getMyPageRetrospectives(userId, null, pageable));
+
+            assertThat(ex.getErrorCode()).isEqualTo(
+                RetrospectiveExceptionType.RETRO_USER_NOT_FOUND);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #160 

## 🚀 작업 내용
- [x] /api/v1/retrospectives/mypage API 추가
- [x] 서비스/레포 계층: 페이지 조회 + 전체 회고 집계용 쿼리 메서드 추가
- [x] 컨버터가 회고 목록 요약과 성공/실패 요인 TOP3 통계를 생성하도록 확장, 응답용 DTO 묶음 구현(statistics+retrospectives PageResponse)
- [x] RetrospectiveServiceTest 추가


## 🔍 리뷰 요청 사항 및 공유자료
작동과 필터링, 페이지네이션이 잘 작동되는지 (swagger 예시 참조)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
10m+
