### PR TITLE
[fix] subtemplate 오류 수정

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/templates/domain/Template.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/templates/domain/Template.java
@@ -24,6 +24,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "templates", indexes = {
@@ -56,6 +57,7 @@ public class Template extends BaseTimeEntity {
     private Integer duration;
 
     @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Where(clause = "status = 'ACTIVE'")
     private List<SubTemplate> subTemplates;
 
     @Builder.Default


### PR DESCRIPTION


## 📝 수정 요약
JPA에서 가져올때 subtemplate 리스트에 status.ACTIVE 조건을 걸지 않아서 삭제한 리스트까지 조회

- 🚨 문제점
    - 파싱 안함

- 🔍 원인 분석
    - 파싱 안함

- 💡 해결 방법
    - @Where(clause = "status = 'ACTIVE'") 추가

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5+