### PR TITLE
[feat] 월별 goal 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/controller/GoalController.java
@@ -3,6 +3,7 @@ package com.hotpack.krocs.domain.goals.controller;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.MonthlyGoalCountResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
@@ -69,6 +70,23 @@ public class GoalController {
     ) {
         try {
             List<GoalResponseDTO> result = goalService.getGoalsByUser(userId, searchDate, keyword, status);
+            return ApiResponse.success(result);
+        } catch (GoalException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
+        }
+    }
+
+    @Operation(summary = "월별 목표 개수 조회", description = "특정 년월의 날짜별 목표 개수를 조회합니다.")
+    @GetMapping("/monthly/count")
+    public ApiResponse<MonthlyGoalCountResponseDTO> getMonthlyGoalCounts(
+            @Login Long userId,
+            @RequestParam @Parameter(description = "년도", example = "2025") Integer year,
+            @RequestParam @Parameter(description = "월", example = "9") Integer month
+    ) {
+        try {
+            MonthlyGoalCountResponseDTO result = goalService.getMonthlyGoalCounts(year, month, userId);
             return ApiResponse.success(result);
         } catch (GoalException e) {
             throw e;

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/DailyGoalCountDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/DailyGoalCountDTO.java
@@ -1,0 +1,18 @@
+package com.hotpack.krocs.domain.goals.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DailyGoalCountDTO {
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    @JsonProperty("goal_count")
+    private Integer goalCount;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/MonthlyGoalCountResponseDTO.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/dto/response/MonthlyGoalCountResponseDTO.java
@@ -1,0 +1,17 @@
+package com.hotpack.krocs.domain.goals.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MonthlyGoalCountResponseDTO {
+
+    private Integer year;
+    private Integer month;
+
+    @JsonProperty("daily_goals")
+    private List<DailyGoalCountDTO> dailyGoals;
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/exception/GoalExceptionType.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/exception/GoalExceptionType.java
@@ -22,7 +22,10 @@ public enum GoalExceptionType implements BaseCode {
     GOAL_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "GOAL400", "목표 제목이 너무 깁니다."),
     GOAL_INVALID_PRIORITY(HttpStatus.BAD_REQUEST, "GOAL400", "유효하지 않은 우선순위입니다."),
     GOAL_DURATION_TOO_LONG(HttpStatus.BAD_REQUEST, "GOAL400", "목표 기간이 너무 깁니다."),
-    GOAL_INVALID_GOAL_ID(HttpStatus.BAD_REQUEST, "GOAL400", "유효하지 않은 목표 ID입니다.");
+    GOAL_INVALID_GOAL_ID(HttpStatus.BAD_REQUEST, "GOAL400", "유효하지 않은 목표 ID입니다."),
+    GOAL_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "GOAL400", "요청 형식이 잘못되었습니다."),
+    GOAL_INVALID_YEAR(HttpStatus.BAD_REQUEST, "GOAL400", "유효하지 않은 년도입니다."),
+    GOAL_INVALID_MONTH(HttpStatus.BAD_REQUEST, "GOAL400", "유효하지 않은 월입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/facade/GoalRepositoryFacade.java
@@ -1,6 +1,7 @@
 package com.hotpack.krocs.domain.goals.facade;
 
 import com.hotpack.krocs.domain.goals.domain.Goal;
+import com.hotpack.krocs.domain.goals.repository.DailyGoalCountProjection;
 import com.hotpack.krocs.domain.goals.repository.GoalRepository;
 import com.hotpack.krocs.domain.user.domain.User;
 import com.hotpack.krocs.global.common.entity.Status;
@@ -34,6 +35,15 @@ public class GoalRepositoryFacade {
 
     public List<Goal> findGoalsWithFilters(Long userId, String keyword, LocalDate searchDate) {
         return goalRepository.findGoalsWithFilters(userId, keyword, searchDate);
+    }
+
+    public List<DailyGoalCountProjection> findActiveDailyGoalCountsByMonth(int year, int month, Long userId) {
+        LocalDate startOfMonth = LocalDate.of(year, month, 1);
+        LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+
+        return goalRepository.findDailyGoalCountsByMonth(
+                startOfMonth, endOfMonth, userId, Status.ACTIVE.name()
+        );
     }
 
     public Goal findActiveGoalByUserAndGoalId(User user, Long goalId) {

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/DailyGoalCountProjection.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/DailyGoalCountProjection.java
@@ -1,0 +1,9 @@
+package com.hotpack.krocs.domain.goals.repository;
+
+import java.time.LocalDate;
+
+public interface DailyGoalCountProjection {
+    LocalDate getDate();
+
+    Integer getGoalCount();
+}

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/GoalRepository.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/repository/GoalRepository.java
@@ -37,6 +37,24 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
             @Param("searchDate") LocalDate searchDate
     );
 
+    @Query(value = """
+            SELECT d::date AS date, COUNT(g.goal_id)::int AS goalCount
+            FROM generate_series(CAST(:startOfMonth AS date), CAST(:endOfMonth AS date), interval '1 day') d
+            LEFT JOIN goals g
+              ON g.user_id = :userId
+             AND g.status = :status
+             AND (g.start_date IS NULL OR g.start_date <= d::date)
+             AND (g.end_date IS NULL OR g.end_date >= d::date)
+            GROUP BY d
+            ORDER BY d
+            """, nativeQuery = true)
+    List<DailyGoalCountProjection> findDailyGoalCountsByMonth(
+            @Param("startOfMonth") LocalDate startOfMonth,
+            @Param("endOfMonth") LocalDate endOfMonth,
+            @Param("userId") Long userId,
+            @Param("status") String status
+    );
+
     boolean existsGoalByGoalIdAndStatus(Long goalId, Status status);
 
     boolean existsGoalByTitleAndStatus(String title, Status status);

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalService.java
@@ -5,6 +5,7 @@ import com.hotpack.krocs.domain.goals.dto.request.GoalSearchRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.MonthlyGoalCountResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,6 +14,8 @@ public interface GoalService {
     GoalCreateResponseDTO createGoal(GoalCreateRequestDTO requestDTO, Long userId);
 
     List<GoalResponseDTO> getGoalsByUser(Long userId, LocalDate searchDate, String keyword, String status);
+
+    MonthlyGoalCountResponseDTO getMonthlyGoalCounts(int year, int month, Long userId);
 
     GoalResponseDTO getGoalByGoalId(Long userId, Long goalId);
 

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalServiceImpl.java
@@ -5,8 +5,10 @@ import com.hotpack.krocs.domain.goals.domain.Goal;
 import com.hotpack.krocs.domain.goals.dto.request.GoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalSearchRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.GoalUpdateRequestDTO;
+import com.hotpack.krocs.domain.goals.dto.response.DailyGoalCountDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.MonthlyGoalCountResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
 import com.hotpack.krocs.domain.goals.exception.GoalExceptionType;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
@@ -99,6 +101,38 @@ public class GoalServiceImpl implements GoalService {
             throw e;
         } catch (Exception e) {
             log.error("대목표 전체 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
+        }
+    }
+
+    @Override
+    public MonthlyGoalCountResponseDTO getMonthlyGoalCounts(int year, int month, Long userId) {
+        try {
+            goalValidator.validateMonthlyGoalRequest(year, month);
+
+            User user = userRepositoryFacade.findActiveUserByUserId(userId);
+            if (user == null) {
+                throw new GoalException(GoalExceptionType.GOAL_USER_NOT_FOUND);
+            }
+
+            List<DailyGoalCountDTO> dailyGoalCounts = goalRepositoryFacade.findActiveDailyGoalCountsByMonth(
+                            year, month, userId
+                    ).stream()
+                    .map(row -> DailyGoalCountDTO.builder()
+                            .date(row.getDate())
+                            .goalCount(row.getGoalCount())
+                            .build())
+                    .collect(Collectors.toList());
+
+            return MonthlyGoalCountResponseDTO.builder()
+                    .year(year)
+                    .month(month)
+                    .dailyGoals(dailyGoalCounts)
+                    .build();
+        } catch (GoalException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("월별 목표 개수 조회 중 예상치 못한 오류 발생: {}", e.getMessage(), e);
             throw new GoalException(GoalExceptionType.GOAL_FOUND_FAILED);
         }
     }

--- a/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalValidator.java
+++ b/backend/src/main/java/com/hotpack/krocs/domain/goals/service/GoalValidator.java
@@ -46,4 +46,18 @@ public class GoalValidator {
             throw new GoalException(GoalExceptionType.INVALID_GOAL_DATE_RANGE);
         }
     }
+
+    public void validateMonthlyGoalRequest(Integer year, Integer month) {
+        if (year == null || month == null) {
+            throw new GoalException(GoalExceptionType.GOAL_INVALID_REQUEST);
+        }
+
+        if (year < 2000 || year > 3000) {
+            throw new GoalException(GoalExceptionType.GOAL_INVALID_YEAR);
+        }
+
+        if (month < 1 || month > 12) {
+            throw new GoalException(GoalExceptionType.GOAL_INVALID_MONTH);
+        }
+    }
 }

--- a/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/hotpack/krocs/domain/goals/service/GoalServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -21,6 +23,7 @@ import com.hotpack.krocs.domain.goals.dto.request.SubGoalCreateRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.request.SubGoalRequestDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.GoalResponseDTO;
+import com.hotpack.krocs.domain.goals.dto.response.MonthlyGoalCountResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalCreateResponseDTO;
 import com.hotpack.krocs.domain.goals.dto.response.SubGoalResponseDTO;
 import com.hotpack.krocs.domain.goals.exception.GoalException;
@@ -29,6 +32,7 @@ import com.hotpack.krocs.domain.goals.exception.SubGoalException;
 import com.hotpack.krocs.domain.goals.exception.SubGoalExceptionType;
 import com.hotpack.krocs.domain.goals.facade.GoalRepositoryFacade;
 import com.hotpack.krocs.domain.goals.facade.SubGoalRepositoryFacade;
+import com.hotpack.krocs.domain.goals.repository.DailyGoalCountProjection;
 import com.hotpack.krocs.domain.retrospectives.domain.Retrospective;
 import com.hotpack.krocs.domain.retrospectives.domain.RetrospectiveOutcome;
 import com.hotpack.krocs.domain.user.domain.User;
@@ -107,6 +111,20 @@ class GoalServiceTest {
             .priority(Priority.MEDIUM)
             .isCompleted(false)
             .build();
+    }
+
+    private DailyGoalCountProjection createDailyGoalCountProjection(LocalDate date, Integer goalCount) {
+        return new DailyGoalCountProjection() {
+            @Override
+            public LocalDate getDate() {
+                return date;
+            }
+
+            @Override
+            public Integer getGoalCount() {
+                return goalCount;
+            }
+        };
     }
 
     @BeforeEach
@@ -1153,6 +1171,80 @@ class GoalServiceTest {
         // Repository 호출 검증
         verify(goalRepositoryFacade).findGoalsWithFilters(userId, keyword, searchDate);
         verify(goalConverter).toGoalSearchRequestDTO(searchDate, keyword, status);
+    }
+
+    @Test
+    @DisplayName("월별 날짜별 목표 개수 조회 성공")
+    void getMonthlyGoalCounts_Success() {
+        // given
+        Long userId = 1L;
+        int year = 2025;
+        int month = 9;
+
+        List<DailyGoalCountProjection> dailyCounts = Arrays.asList(
+            createDailyGoalCountProjection(LocalDate.of(2025, 9, 1), 2),
+            createDailyGoalCountProjection(LocalDate.of(2025, 9, 2), 2),
+            createDailyGoalCountProjection(LocalDate.of(2025, 9, 3), 1),
+            createDailyGoalCountProjection(LocalDate.of(2025, 9, 30), 1)
+        );
+
+        when(userRepositoryFacade.findActiveUserByUserId(userId)).thenReturn(user);
+        when(goalRepositoryFacade.findActiveDailyGoalCountsByMonth(year, month, userId)).thenReturn(
+            dailyCounts);
+
+        // when
+        MonthlyGoalCountResponseDTO result = goalService.getMonthlyGoalCounts(year, month, userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getYear()).isEqualTo(year);
+        assertThat(result.getMonth()).isEqualTo(month);
+        assertThat(result.getDailyGoals()).hasSize(4);
+
+        assertThat(result.getDailyGoals().stream()
+            .filter(daily -> daily.getDate().equals(LocalDate.of(2025, 9, 1)))
+            .findFirst()
+            .orElseThrow()
+            .getGoalCount()).isEqualTo(2);
+
+        assertThat(result.getDailyGoals().stream()
+            .filter(daily -> daily.getDate().equals(LocalDate.of(2025, 9, 3)))
+            .findFirst()
+            .orElseThrow()
+            .getGoalCount()).isEqualTo(1);
+
+        assertThat(result.getDailyGoals().stream()
+            .filter(daily -> daily.getDate().equals(LocalDate.of(2025, 9, 30)))
+            .findFirst()
+            .orElseThrow()
+            .getGoalCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("월별 날짜별 목표 개수 조회 실패 - 사용자 없음")
+    void getMonthlyGoalCounts_Fail_UserNotFound() {
+        // given
+        Long userId = 1L;
+        int year = 2025;
+        int month = 9;
+
+        when(userRepositoryFacade.findActiveUserByUserId(userId)).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> goalService.getMonthlyGoalCounts(year, month, userId))
+            .isInstanceOf(GoalException.class)
+            .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("월별 날짜별 목표 개수 조회 실패 - 유효하지 않은 월")
+    void getMonthlyGoalCounts_Fail_InvalidMonth() {
+        // when & then
+        assertThatThrownBy(() -> goalService.getMonthlyGoalCounts(2025, 13, 1L))
+            .isInstanceOf(GoalException.class)
+            .hasFieldOrPropertyWithValue("goalExceptionType", GoalExceptionType.GOAL_INVALID_MONTH);
+
+        verify(goalRepositoryFacade, never()).findActiveDailyGoalCountsByMonth(anyInt(), anyInt(), anyLong());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #169 

## 🚀 작업 내용
- [x] 기존 백엔드에 월별 목표 조회가 아닌 일정/소목표 조회로 캘린더 적용해 정확한 개수가 나오지 않음
- [x] `/api/v1/goals/monthly/count` 목표 개수 조회 API 추가
- [x] `GoalServiceImpl.getMonthlyGoalCounts` 메서드 추가
- [x] `GoalRepository.findDailyGoalCountsByMonth`에서 일별 개수 count

## 🔍 리뷰 요청 사항 및 공유자료
- `/api/v1/goals/monthly/count`를 통한 월별 개수 조회가 작동하는지
- 초별 오차 문제가 없는지 확인 부탁드립니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
10+
